### PR TITLE
fix: round 2 code review fixes — PostToolUse hook, .venv/bin/python3, tests, uninstall docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- code-search:start -->
 ## Precision Protocol
-1. **Search First:** Run `source .venv/bin/activate && python3 search_code.py "<query>"` to find relevant chunks.
+1. **Search First:** Run `.venv/bin/python3 search_code.py "<query>"` to find relevant chunks.
 2. **Verify:** Use the `Read` tool on the path from the search result.
 3. **Validate:** If it's the wrong spot, refine the search query and repeat.
 4. **Edit:** Only modify once the file content is verified.

--- a/README.md
+++ b/README.md
@@ -64,10 +64,15 @@ curl -fsSL https://raw.githubusercontent.com/jjveleber/code-search/main/install.
 ## Uninstall
 
 ```bash
-rm -rf index_project.py search_code.py chroma_db/
+rm -rf index_project.py search_code.py chroma_db/ .venv/
 ```
 
-Then remove the block between `<!-- code-search:start -->` and `<!-- code-search:end -->` from `CLAUDE.md`, and remove the `chroma_db/` line from `.gitignore`.
+> **Note:** Omit `.venv/` if it predated this installation (i.e. you brought your own virtual environment).
+
+Then:
+- Remove the block between `<!-- code-search:start -->` and `<!-- code-search:end -->` from `CLAUDE.md`
+- Remove the `chroma_db/` line from `.gitignore`
+- Remove the `PostToolUse` hook entry from `.claude/settings.local.json` (the entry with `"command": ".venv/bin/python3 index_project.py"`)
 
 ## Environment Variables
 

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ if [ "$VENV_EXISTED" = true ]; then
 fi
 
 # Step 4: Install chromadb
-"$VENV_PATH/bin/pip" install "chromadb>=1.0" --quiet
+"$VENV_PATH/bin/pip" install "chromadb>=1.0"
 
 # Restore venv directory mtime to signal reuse (not recreation)
 if [ "$VENV_EXISTED" = true ] && [ -n "${_VENV_MTIME_REF:-}" ]; then
@@ -82,7 +82,7 @@ fi
 SENTINEL="<!-- code-search:start -->"
 CLAUDE_BLOCK="<!-- code-search:start -->
 ## Precision Protocol
-1. **Search First:** Run \`source .venv/bin/activate && python3 search_code.py \"<query>\"\` to find relevant chunks.
+1. **Search First:** Run \`.venv/bin/python3 search_code.py \"<query>\"\` to find relevant chunks.
 2. **Verify:** Use the \`Read\` tool on the path from the search result.
 3. **Validate:** If it's the wrong spot, refine the search query and repeat.
 4. **Edit:** Only modify once the file content is verified.
@@ -100,7 +100,50 @@ else
     echo "Precision Protocol already in CLAUDE.md"
 fi
 
-# Step 8: Run first index (skip if index already exists)
+# Step 8: Install PostToolUse hook into .claude/settings.local.json
+SETTINGS_FILE=".claude/settings.local.json"
+mkdir -p ".claude"
+
+python3 - <<'PYEOF'
+import json, os, sys
+
+settings_file = os.environ.get("SETTINGS_FILE", ".claude/settings.local.json")
+
+hook_entry = {
+    "matcher": "Edit|Write",
+    "hooks": [
+        {
+            "type": "command",
+            "command": ".venv/bin/python3 index_project.py"
+        }
+    ]
+}
+
+if os.path.exists(settings_file):
+    with open(settings_file) as f:
+        try:
+            settings = json.load(f)
+        except json.JSONDecodeError:
+            print(f"Warning: {settings_file} is not valid JSON — overwriting")
+            settings = {}
+else:
+    settings = {}
+
+hooks = settings.setdefault("hooks", {})
+post_tool_use = hooks.setdefault("PostToolUse", [])
+existing_matchers = [h.get("matcher") for h in post_tool_use]
+
+if hook_entry["matcher"] in existing_matchers:
+    print(f"PostToolUse hook already in {settings_file}, skipping")
+else:
+    post_tool_use.append(hook_entry)
+    with open(settings_file, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+    print(f"Added PostToolUse hook to {settings_file}")
+PYEOF
+
+# Step 9: Run first index (skip if index already exists)
 if [ "$IS_GIT_REPO" = true ] && [ ! -d "chroma_db" ]; then
     echo "Building initial index..."
     "$VENV_PATH/bin/python3" index_project.py
@@ -111,5 +154,5 @@ fi
 echo ""
 echo "code-search installed successfully"
 echo "  Venv:     $VENV_PATH"
-echo "  Re-index: source .venv/bin/activate && python3 index_project.py"
-echo "  Search:   source .venv/bin/activate && python3 search_code.py \"<query>\""
+echo "  Re-index: .venv/bin/python3 index_project.py"
+echo "  Search:   .venv/bin/python3 search_code.py \"<query>\""

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -47,7 +47,7 @@ assert "CLAUDE.md created"            "[ -f CLAUDE.md ]"
 assert "Precision Protocol in CLAUDE.md" "grep -q 'code-search:start' CLAUDE.md"
 assert "venv created"                 "[ -d .venv ]"
 assert "chroma_db index built"        "[ -d chroma_db ]"
-assert "CLAUDE.md uses relative venv path"  "grep -q 'source .venv/bin/activate' CLAUDE.md"
+assert "CLAUDE.md search command uses .venv/bin/python3 (not 'source')"  "grep -q '.venv/bin/python3 search_code.py' CLAUDE.md"
 assert "CLAUDE.md does not start with blank line" "[ \"\$(head -c1 CLAUDE.md)\" != $'\n' ]"
 teardown
 
@@ -143,6 +143,33 @@ SECOND_OUTPUT=$(CODE_SEARCH_LOCAL="$REPO_ROOT" bash "$REPO_ROOT/install.sh" 2>&1
 INDEX_MTIME2=$(stat -c %Y chroma_db 2>/dev/null || stat -f %m chroma_db)
 assert "chroma_db not rebuilt on re-install (mtime unchanged)" "[ '$INDEX_MTIME' = '$INDEX_MTIME2' ]"
 assert "second run reports index already exists" "echo '$SECOND_OUTPUT' | grep -q 'already exists'"
+teardown
+
+echo ""
+echo "=== Test 9: PostToolUse hook is correctly structured and /bin/sh-safe ==="
+setup
+git init -q
+git commit -q --allow-empty -m "init"
+CODE_SEARCH_LOCAL="$REPO_ROOT" bash "$REPO_ROOT/install.sh"
+assert "settings.local.json created"              "[ -f .claude/settings.local.json ]"
+assert "hook nested under 'hooks' key (not root)" \
+    "python3 -c \"import json,sys; d=json.load(open('.claude/settings.local.json')); sys.exit(0 if 'hooks' in d and 'PostToolUse' in d.get('hooks',{}) else 1)\""
+assert "hook command uses .venv/bin/python3" \
+    "python3 -c \"import json,sys; d=json.load(open('.claude/settings.local.json')); cmd=d['hooks']['PostToolUse'][0]['hooks'][0]['command']; sys.exit(0 if '.venv/bin/python3' in cmd else 1)\""
+assert "hook command is /bin/sh-safe (no 'source')" \
+    "python3 -c \"import json,sys; d=json.load(open('.claude/settings.local.json')); cmd=d['hooks']['PostToolUse'][0]['hooks'][0]['command']; sys.exit(0 if 'source' not in cmd else 1)\""
+teardown
+
+echo ""
+echo "=== Test 10: CLAUDE.md Precision Protocol uses correct search command ==="
+setup
+git init -q
+git commit -q --allow-empty -m "init"
+CODE_SEARCH_LOCAL="$REPO_ROOT" bash "$REPO_ROOT/install.sh"
+assert "CLAUDE.md search command uses .venv/bin/python3" \
+    "grep -q '.venv/bin/python3 search_code.py' CLAUDE.md"
+assert "CLAUDE.md search command does not misuse 'source' as a path prefix" \
+    "! grep -q 'source .venv/bin/python3' CLAUDE.md"
 teardown
 
 echo ""

--- a/tests/test_search_code.py
+++ b/tests/test_search_code.py
@@ -151,6 +151,40 @@ def test_search_error_includes_original_exception(tmp_path):
     )
 
 
+def test_index_reflects_edits(tmp_path):
+    """After editing a tracked file and re-indexing, the new content appears in the chroma store."""
+    import subprocess as _subprocess
+    shutil.copy("index_project.py", tmp_path / "index_project.py")
+    _subprocess.run(["git", "init", "-q"], cwd=str(tmp_path), check=True)
+    _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=str(tmp_path), check=True)
+    _subprocess.run(["git", "config", "user.name", "T"], cwd=str(tmp_path), check=True)
+
+    source_file = tmp_path / "hello.py"
+    source_file.write_text("def greet():\n    return 'hello'\n")
+    _subprocess.run(["git", "add", "."], cwd=str(tmp_path), check=True)
+    _subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=str(tmp_path), check=True)
+    _subprocess.run([sys.executable, "index_project.py"], cwd=str(tmp_path), check=True)
+
+    # Edit the file with a unique marker and re-commit so git tracks the change
+    source_file.write_text("def greet():\n    # UNIQUE_EDIT_MARKER_7X3Q\n    return 'hello'\n")
+    _subprocess.run(["git", "add", "hello.py"], cwd=str(tmp_path), check=True)
+    _subprocess.run(["git", "commit", "-q", "-m", "add marker"], cwd=str(tmp_path), check=True)
+
+    result = _subprocess.run(
+        [sys.executable, "index_project.py"],
+        capture_output=True, text=True, cwd=str(tmp_path),
+    )
+    assert result.returncode == 0
+    assert "upserted: 1" in result.stdout, f"Expected 1 chunk upserted, got: {result.stdout!r}"
+
+    client = chromadb.PersistentClient(path=str(tmp_path / "chroma_db"))
+    col = client.get_collection("project_code")
+    docs = col.get(where={"path": "hello.py"}, include=["documents"])["documents"]
+    assert any("UNIQUE_EDIT_MARKER_7X3Q" in doc for doc in docs), (
+        "Edit was not reflected in the index after re-indexing"
+    )
+
+
 def test_index_warns_on_unreadable_file(tmp_path):
     """index_project.py prints a warning to stderr when a file cannot be decoded."""
     import subprocess as _subprocess


### PR DESCRIPTION
## Summary

- **`install.sh`**: Add PostToolUse hook into `.claude/settings.local.json` (auto-reindex on Edit/Write); switch CLAUDE.md Precision Protocol and echo output to use `.venv/bin/python3` directly (no `source` needed); remove `--quiet` from pip
- **`CLAUDE.md`**: Update Step 1 search command to `.venv/bin/python3` form
- **`tests/test_install.sh`**: Add Test 9 (hook structure + `/bin/sh`-safety) and Test 10 (CLAUDE.md command correctness); fix misleading Test 1 assertion to check actual search command
- **`tests/test_search_code.py`**: Add `test_index_reflects_edits` — verifies incremental re-index picks up file edits end-to-end
- **`README.md`**: Fix uninstall section — add `.venv/`, PostToolUse hook removal step, and note for pre-existing venvs

## Test plan

- [x] `bash tests/test_install.sh` → All 30 tests passed
- [x] `.venv/bin/pytest tests/test_search_code.py -v` → 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)