### PR TITLE
fix: update install.sh BASE_URL to correct repo name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_OWNER="${CODE_SEARCH_OWNER:-jjveleber}"
-BASE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/code-search/main"
+BASE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/claude-code-search/main"
 
 # Step 1: Check Python version
 PYTHON_MAJOR=$(python3 -c 'import sys; print(sys.version_info.major)')


### PR DESCRIPTION
## Summary
- Corrects the `BASE_URL` in `install.sh` from `code-search` to `claude-code-search` to match the actual repository name

## Test plan
- [ ] Run `install.sh` and verify it fetches files from the correct GitHub URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)