### PR TITLE
feat: migrate existing installs to hook-based watcher on re-run

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -125,7 +125,7 @@ PYEOF
     echo "Updated Precision Protocol in CLAUDE.md"
 fi
 
-# Step 7c: Remove legacy Session Startup section from CLAUDE.md (migrates old installs)
+# Step 7b: Remove legacy Session Startup section from CLAUDE.md (migrates old installs)
 if [ -f "CLAUDE.md" ] && grep -qF "<!-- code-search-watch:start -->" CLAUDE.md; then
     python3 - <<'PYEOF'
 import re, pathlib
@@ -171,15 +171,20 @@ if local_p.exists():
             g for g in post_hooks
             if not any("index_project.py" in h.get("command", "") for h in g.get("hooks", []))
         ]
+        # Note: removes entire group if it contains index_project.py; assumes
+        # the installer-written group contained only that one command.
         if len(filtered) < len(post_hooks):
             local_settings["hooks"]["PostToolUse"] = filtered
             if not local_settings["hooks"]["PostToolUse"]:
                 del local_settings["hooks"]["PostToolUse"]
-            if not local_settings["hooks"]:
+            if not local_settings.get("hooks"):
                 del local_settings["hooks"]
-            local_p.write_text(json.dumps(local_settings, indent=2) + "\n")
+            if not local_settings:
+                local_p.unlink()
+            else:
+                local_p.write_text(json.dumps(local_settings, indent=2) + "\n")
             print("Removed legacy PostToolUse hook from .claude/settings.local.json")
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError, AttributeError, TypeError):
         pass
 
 if not already_present:

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -199,8 +199,24 @@ git commit -q --allow-empty -m "init"
 mkdir -p .claude
 printf '{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":".venv/bin/python3 index_project.py"}]}]}}\n' > .claude/settings.local.json
 CODE_SEARCH_LOCAL="$REPO_ROOT" bash "$REPO_ROOT/install.sh"
-assert "PostToolUse hook removed from settings.local.json" "! grep -q 'PostToolUse' .claude/settings.local.json"
-assert "UserPromptSubmit hook added to settings.json"      "grep -q 'watch_index.py' .claude/settings.json"
+assert "settings.local.json deleted when empty after migration" "[ ! -f .claude/settings.local.json ]"
+assert "UserPromptSubmit hook added to settings.json"          "grep -q 'watch_index.py' .claude/settings.json"
+teardown
+
+echo ""
+echo "=== Test 13: Migration is idempotent — running install.sh twice on an old install ==="
+setup
+git init -q
+git commit -q --allow-empty -m "init"
+# Simulate old install
+printf "<!-- code-search:start -->\n## Precision Protocol\n<!-- code-search:end -->\n\n<!-- code-search-watch:start -->\n## Session Startup\n1. Run index_project.py\n<!-- code-search-watch:end -->\n" > CLAUDE.md
+mkdir -p .claude
+printf '{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":".venv/bin/python3 index_project.py"}]}]}}\n' > .claude/settings.local.json
+CODE_SEARCH_LOCAL="$REPO_ROOT" bash "$REPO_ROOT/install.sh"
+CODE_SEARCH_LOCAL="$REPO_ROOT" bash "$REPO_ROOT/install.sh"
+assert "Session Startup still absent after second run"    "! grep -q 'Session Startup' CLAUDE.md"
+assert "Precision Protocol still present after two runs"  "grep -q 'code-search:start' CLAUDE.md"
+assert "Hook not duplicated after two runs on old install" "[ \"$(grep -c 'watch_index.py' .claude/settings.json)\" = '1' ]"
 teardown
 
 echo ""


### PR DESCRIPTION
## Summary

- When `install.sh` runs on a project with an old install, it now removes the legacy `Session Startup` section from `CLAUDE.md`
- Also removes the legacy `PostToolUse` `index_project.py` hook from `.claude/settings.local.json`
- Addresses the migration gap flagged in PR #8 code review

## Test Plan

- [x] All 38 tests pass (`bash tests/test_install.sh`)
- [x] Test 11: verifies `Session Startup` removed from CLAUDE.md on re-install
- [x] Test 12: verifies `PostToolUse` hook removed from `settings.local.json` and new `UserPromptSubmit` hook added

🤖 Generated with [Claude Code](https://claude.com/claude-code)