### PR TITLE
fix: PID race condition, inotify read-loop, gitignored re-index; index untracked files

### DIFF
--- a/index_project.py
+++ b/index_project.py
@@ -11,11 +11,22 @@ CHUNK_OVERLAP = 10
 CHUNK_MAX = 120
 
 
-def git_tracked_files():
-    result = subprocess.run(
+def git_indexable_files():
+    """Return tracked files plus untracked non-ignored files."""
+    tracked = subprocess.run(
         ["git", "ls-files"], capture_output=True, text=True, check=True
-    )
-    return [f for f in result.stdout.splitlines() if f.strip()]
+    ).stdout.splitlines()
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    seen = set()
+    result = []
+    for f in tracked + untracked:
+        if f.strip() and f not in seen:
+            seen.add(f)
+            result.append(f)
+    return result
 
 
 def chunk_lines(lines):
@@ -66,7 +77,7 @@ def index_files():
     for chunk_id, meta in zip(existing["ids"], existing["metadatas"]):
         existing_hashes[chunk_id] = meta.get("hash", "")
 
-    tracked_files = git_tracked_files()
+    tracked_files = git_indexable_files()
     tracked_set = set(tracked_files)
 
     # Find chunk IDs that belong to files no longer tracked

--- a/tests/test_index_project.py
+++ b/tests/test_index_project.py
@@ -1,0 +1,63 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from index_project import git_indexable_files
+
+
+def _fake_run(tracked, untracked):
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = "\n".join(untracked if "--others" in cmd else tracked)
+        if result.stdout:
+            result.stdout += "\n"
+        return result
+    return _run
+
+
+def test_includes_tracked_files():
+    with patch("index_project.subprocess.run", side_effect=_fake_run(["main.py", "utils.py"], [])):
+        files = git_indexable_files()
+    assert "main.py" in files
+    assert "utils.py" in files
+
+
+def test_includes_untracked_non_ignored_files():
+    """New files created by Claude Code (not yet staged) must appear in the index."""
+    with patch("index_project.subprocess.run", side_effect=_fake_run(["main.py"], ["SUMMARY.md"])):
+        files = git_indexable_files()
+    assert "main.py" in files
+    assert "SUMMARY.md" in files
+
+
+def test_no_duplicates_when_file_in_both_lists():
+    with patch("index_project.subprocess.run", side_effect=_fake_run(["main.py"], ["main.py"])):
+        files = git_indexable_files()
+    assert files.count("main.py") == 1
+
+
+def test_empty_lines_excluded():
+    with patch("index_project.subprocess.run", side_effect=_fake_run(["main.py", ""], ["", "new.py"])):
+        files = git_indexable_files()
+    assert "" not in files
+
+
+def test_untracked_query_uses_exclude_standard():
+    """--exclude-standard ensures gitignored files are not returned as untracked."""
+    calls = []
+    def capturing_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        r = MagicMock()
+        r.stdout = ""
+        return r
+
+    with patch("index_project.subprocess.run", side_effect=capturing_run):
+        git_indexable_files()
+
+    untracked_calls = [c for c in calls if "--others" in c]
+    assert untracked_calls, "expected a call with --others"
+    assert "--exclude-standard" in untracked_calls[0]

--- a/tests/test_search_code.py
+++ b/tests/test_search_code.py
@@ -159,6 +159,7 @@ def test_index_reflects_edits(tmp_path):
     _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=str(tmp_path), check=True)
     _subprocess.run(["git", "config", "user.name", "T"], cwd=str(tmp_path), check=True)
 
+    (tmp_path / ".gitignore").write_text("chroma_db/\n")
     source_file = tmp_path / "hello.py"
     source_file.write_text("def greet():\n    return 'hello'\n")
     _subprocess.run(["git", "add", "."], cwd=str(tmp_path), check=True)

--- a/tests/test_watch_index.py
+++ b/tests/test_watch_index.py
@@ -12,11 +12,70 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from watch_index import (
     DebounceReindexer,
     ReindexHandler,
+    acquire_pid_lock,
     cleanup_pid,
     is_already_running,
     should_ignore,
     write_pid,
 )
+
+
+# ── Atomic PID lock ────────────────────────────────────────────────────────────
+
+def test_acquire_pid_lock_creates_pid_file(tmp_path):
+    """acquire_pid_lock creates PID file containing the current PID."""
+    pid_file = str(tmp_path / "test.pid")
+    fh = acquire_pid_lock(pid_file)
+    assert fh is not None
+    assert Path(pid_file).read_text().strip() == str(os.getpid())
+    fh.close()
+
+
+def test_acquire_pid_lock_fails_when_another_process_holds_it(tmp_path):
+    """acquire_pid_lock returns None when another process holds the lock."""
+    import subprocess
+    pid_file = str(tmp_path / "test.pid")
+    holder = subprocess.Popen([
+        sys.executable, "-c",
+        f"import fcntl, time; f=open(r'{pid_file}','a');"
+        f"fcntl.flock(f, fcntl.LOCK_EX); f.write('99999'); f.flush(); time.sleep(10)"
+    ])
+    time.sleep(0.1)
+    try:
+        result = acquire_pid_lock(pid_file)
+        assert result is None
+    finally:
+        holder.terminate()
+        holder.wait()
+
+
+def test_acquire_pid_lock_succeeds_after_release(tmp_path):
+    """acquire_pid_lock succeeds once a prior lock is released."""
+    pid_file = str(tmp_path / "test.pid")
+    fh = acquire_pid_lock(pid_file)
+    assert fh is not None
+    fh.close()  # release
+    fh2 = acquire_pid_lock(pid_file)
+    assert fh2 is not None
+    fh2.close()
+
+
+def test_acquire_pid_lock_does_not_corrupt_existing_pid_on_failure(tmp_path):
+    """If lock is held, the existing PID file content is not corrupted."""
+    import subprocess
+    pid_file = str(tmp_path / "test.pid")
+    holder = subprocess.Popen([
+        sys.executable, "-c",
+        f"import fcntl, time; f=open(r'{pid_file}','a');"
+        f"fcntl.flock(f, fcntl.LOCK_EX); f.write('12345'); f.flush(); time.sleep(10)"
+    ])
+    time.sleep(0.1)
+    try:
+        acquire_pid_lock(pid_file)  # should fail
+        assert "12345" in Path(pid_file).read_text()
+    finally:
+        holder.terminate()
+        holder.wait()
 
 
 # ── PID guard ──────────────────────────────────────────────────────────────────
@@ -169,5 +228,77 @@ def test_handler_triggers_for_regular_file():
     event = MagicMock()
     event.is_directory = False
     event.src_path = "index_project.py"
+    event.event_type = "modified"
     handler.on_any_event(event)
     reindexer.trigger.assert_called_once()
+
+
+def test_handler_ignores_opened_event():
+    """opened events are read-only — index_project.py reading files must not trigger a re-index."""
+    reindexer = MagicMock()
+    handler = ReindexHandler(reindexer)
+    event = MagicMock()
+    event.is_directory = False
+    event.src_path = "index_project.py"
+    event.event_type = "opened"
+    handler.on_any_event(event)
+    reindexer.trigger.assert_not_called()
+
+
+def test_handler_ignores_closed_no_write_event():
+    """closed_no_write events are read-only — must not trigger a re-index."""
+    reindexer = MagicMock()
+    handler = ReindexHandler(reindexer)
+    event = MagicMock()
+    event.is_directory = False
+    event.src_path = "index_project.py"
+    event.event_type = "closed_no_write"
+    handler.on_any_event(event)
+    reindexer.trigger.assert_not_called()
+
+
+def test_handler_ignores_gitignored_file():
+    """Files ignored by git (e.g. build artifacts) must not trigger a re-index."""
+    reindexer = MagicMock()
+    handler = ReindexHandler(reindexer)
+    event = MagicMock()
+    event.is_directory = False
+    event.src_path = "build/output.js"
+    event.event_type = "modified"
+    with patch("watch_index.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)  # git check-ignore: IS ignored
+        handler.on_any_event(event)
+    reindexer.trigger.assert_not_called()
+
+
+def test_handler_triggers_for_untracked_non_ignored_file():
+    """New untracked files that are not gitignored should trigger a re-index."""
+    reindexer = MagicMock()
+    handler = ReindexHandler(reindexer)
+    event = MagicMock()
+    event.is_directory = False
+    event.src_path = "SUMMARY.md"
+    event.event_type = "created"
+    with patch("watch_index.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1)  # git check-ignore: NOT ignored
+        handler.on_any_event(event)
+    reindexer.trigger.assert_called_once()
+
+
+def test_handler_logs_triggering_path(tmp_path, monkeypatch):
+    """on_any_event logs the path and event type that caused the trigger."""
+    monkeypatch.chdir(tmp_path)
+    log_file = tmp_path / ".watch_index.log"
+
+    reindexer = MagicMock()
+    handler = ReindexHandler(reindexer)
+    event = MagicMock()
+    event.is_directory = False
+    event.src_path = "src/app.py"
+    event.event_type = "modified"
+    handler.on_any_event(event)
+
+    assert log_file.exists(), "log file should be written"
+    contents = log_file.read_text()
+    assert "src/app.py" in contents
+    assert "modified" in contents

--- a/watch_index.py
+++ b/watch_index.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """watch_index.py — re-index ChromaDB whenever project files change."""
 
+import fcntl
 import os
 import signal
 import subprocess
@@ -41,12 +42,47 @@ def write_pid(pid_file=PID_FILE):
         f.write(str(os.getpid()))
 
 
+def acquire_pid_lock(pid_file=PID_FILE):
+    """Atomically acquire exclusive PID lock.
+
+    Returns an open file handle on success (caller must keep it open to hold
+    the lock), or None if another process already holds it.  Using flock
+    eliminates the TOCTOU race in the old is_already_running/write_pid pair.
+    """
+    try:
+        fh = open(pid_file, "a")          # create if absent; never truncates
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fh.seek(0)
+        fh.truncate()
+        fh.write(str(os.getpid()))
+        fh.flush()
+        return fh
+    except OSError:
+        try:
+            fh.close()
+        except Exception:
+            pass
+        return None
+
+
 def cleanup_pid(pid_file=PID_FILE):
     """Remove pid_file, silently ignore if missing."""
     try:
         os.remove(pid_file)
     except FileNotFoundError:
         pass
+
+
+def is_git_ignored(path):
+    """Return True if path is git-ignored (i.e. git check-ignore exits 0)."""
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", path],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    except OSError:
+        return False
 
 
 def should_ignore(path):
@@ -101,8 +137,13 @@ class ReindexHandler(FileSystemEventHandler):
     def on_any_event(self, event):
         if event.is_directory:
             return
+        if event.event_type in ("opened", "closed_no_write"):
+            return
         if should_ignore(event.src_path):
             return
+        if is_git_ignored(event.src_path):
+            return
+        _log(f"triggered by: {event.src_path} ({event.event_type})")
         self._reindexer.trigger()
 
 
@@ -112,7 +153,8 @@ def _log(msg):
 
 
 def main():
-    if is_already_running():
+    lock_fh = acquire_pid_lock()
+    if lock_fh is None:
         try:
             with open(PID_FILE) as f:
                 pid = f.read().strip()
@@ -121,9 +163,8 @@ def main():
         print(f"watcher already running (PID: {pid})")
         sys.exit(0)
 
-    write_pid()
-
     def _cleanup(signum=None, frame=None):
+        lock_fh.close()
         cleanup_pid()
         sys.exit(0)
 


### PR DESCRIPTION
## Summary

- **watch_index.py — PID guard race condition**: replaced `is_already_running()` + `write_pid()` with `acquire_pid_lock()` using `fcntl.flock` — prevents multiple watcher instances when the hook fires rapidly at session start
- **watch_index.py — read-loop**: filter out `opened` and `closed_no_write` watchdog event types — `index_project.py` reading files was generating inotify events that triggered re-indexing infinitely
- **watch_index.py — gitignored files**: added `is_git_ignored()` using `git check-ignore -q` to skip gitignored files; also logs the triggering path/event type for diagnostics
- **index_project.py**: `git_tracked_files()` renamed to `git_indexable_files()` and expanded to include untracked non-ignored files via `git ls-files --others --exclude-standard`, so files created by Claude Code during a session are indexed immediately without requiring `git add`
- **tests**: new tests for all `watch_index.py` changes, new `tests/test_index_project.py` for `git_indexable_files()`, fix `test_index_reflects_edits` to add `.gitignore` in tmp repo (needed now that untracked files are scanned)

## Test plan

- [x] All 47 tests pass (`python -m pytest tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)