### PR TITLE
fix: always exclude chroma_db/ from git_indexable_files

### DIFF
--- a/index_project.py
+++ b/index_project.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import subprocess
 import sys
 import chromadb
@@ -20,10 +21,11 @@ def git_indexable_files():
         ["git", "ls-files", "--others", "--exclude-standard"],
         capture_output=True, text=True, check=True,
     ).stdout.splitlines()
+    chroma_dir = os.path.normpath(CHROMA_PATH)
     seen = set()
     result = []
     for f in tracked + untracked:
-        if f.strip() and f not in seen:
+        if f.strip() and f not in seen and not f.startswith(chroma_dir + "/") and f != chroma_dir:
             seen.add(f)
             result.append(f)
     return result

--- a/tests/test_index_project.py
+++ b/tests/test_index_project.py
@@ -46,6 +46,41 @@ def test_empty_lines_excluded():
     assert "" not in files
 
 
+def test_chroma_db_excluded_from_tracked():
+    """chroma_db/ must never be indexed even if tracked by git."""
+    with patch("index_project.subprocess.run", side_effect=_fake_run(
+        ["main.py", "chroma_db/chroma.sqlite3", "chroma_db/uuid/data_level0.bin"], []
+    )):
+        files = git_indexable_files()
+    assert not any(f.startswith("chroma_db") for f in files)
+
+
+def test_chroma_db_excluded_from_untracked():
+    """chroma_db/ must never be indexed even if untracked and not gitignored."""
+    with patch("index_project.subprocess.run", side_effect=_fake_run(
+        ["main.py"], ["chroma_db/chroma.sqlite3", "SUMMARY.md"]
+    )):
+        files = git_indexable_files()
+    assert not any(f.startswith("chroma_db") for f in files)
+    assert "SUMMARY.md" in files
+
+
+def test_chroma_db_exclusion_tracks_chroma_path():
+    """Exclusion must use CHROMA_PATH so a rename stays consistent."""
+    import index_project as _ip
+    original = _ip.CHROMA_PATH
+    try:
+        _ip.CHROMA_PATH = "./my_index"
+        with patch("index_project.subprocess.run", side_effect=_fake_run(
+            ["main.py", "my_index/chroma.sqlite3"], []
+        )):
+            files = _ip.git_indexable_files()
+        assert not any(f.startswith("my_index") for f in files)
+        assert "main.py" in files
+    finally:
+        _ip.CHROMA_PATH = original
+
+
 def test_untracked_query_uses_exclude_standard():
     """--exclude-standard ensures gitignored files are not returned as untracked."""
     calls = []


### PR DESCRIPTION
## Summary

- `git_indexable_files()` now unconditionally skips any path starting with `chroma_db/` (or exactly `chroma_db`)
- Without this guard, users without `chroma_db/` in their `.gitignore` would silently index the vector database into itself on every re-index run, corrupting the index
- Two new tests verify the exclusion applies to both tracked and untracked paths

## Test plan

- [x] `test_chroma_db_excluded_from_tracked` — chroma_db files in git ls-files are filtered
- [x] `test_chroma_db_excluded_from_untracked` — chroma_db files from --others are filtered; non-chroma untracked files still included
- [x] All 49 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)