### PR TITLE
fix: normalize chroma_dir to forward slashes for git path comparison

### DIFF
--- a/index_project.py
+++ b/index_project.py
@@ -21,7 +21,7 @@ def git_indexable_files():
         ["git", "ls-files", "--others", "--exclude-standard"],
         capture_output=True, text=True, check=True,
     ).stdout.splitlines()
-    chroma_dir = os.path.normpath(CHROMA_PATH)
+    chroma_dir = os.path.normpath(CHROMA_PATH).replace("\\", "/")
     seen = set()
     result = []
     for f in tracked + untracked:

--- a/tests/test_index_project.py
+++ b/tests/test_index_project.py
@@ -81,6 +81,23 @@ def test_chroma_db_exclusion_tracks_chroma_path():
         _ip.CHROMA_PATH = original
 
 
+def test_chroma_db_exclusion_uses_forward_slashes():
+    """Exclusion must work even when os.path.normpath returns backslash-separated paths (Windows)."""
+    import index_project as _ip
+    original = _ip.CHROMA_PATH
+    try:
+        _ip.CHROMA_PATH = "./data/chroma_db"
+        with patch("index_project.os.path.normpath", return_value="data\\chroma_db"), \
+             patch("index_project.subprocess.run", side_effect=_fake_run(
+                 ["main.py", "data/chroma_db/chroma.sqlite3"], []
+             )):
+            files = _ip.git_indexable_files()
+        assert not any(f.startswith("data/chroma_db") for f in files)
+        assert "main.py" in files
+    finally:
+        _ip.CHROMA_PATH = original
+
+
 def test_untracked_query_uses_exclude_standard():
     """--exclude-standard ensures gitignored files are not returned as untracked."""
     calls = []


### PR DESCRIPTION
## Summary

- `os.path.normpath` returns backslash-separated paths on Windows, but `git ls-files` always uses forward slashes
- A nested `CHROMA_PATH` like `"./data/chroma_db"` would produce `"data\chroma_db"` on Windows, causing the `startswith` check to silently fail and chroma_db files to slip into the index
- Fix: `.replace("\\", "/")` after `normpath` ensures both sides of the comparison always use forward slashes
- New test simulates Windows behavior by patching `os.path.normpath` to return a backslash path

## Test plan

- [x] `test_chroma_db_exclusion_uses_forward_slashes` — patches normpath to return Windows-style backslash path, verifies exclusion still works
- [x] All 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)