### PR TITLE
fix: batch ChromaDB upserts/deletes to respect max batch size

### DIFF
--- a/index_project.py
+++ b/index_project.py
@@ -10,6 +10,21 @@ COLLECTION_NAME = "project_code"
 CHUNK_TARGET = 60
 CHUNK_OVERLAP = 10
 CHUNK_MAX = 120
+CHROMA_MAX_BATCH = 5000
+
+
+def _batch_upsert(collection, docs, metas, ids):
+    for i in range(0, len(ids), CHROMA_MAX_BATCH):
+        collection.upsert(
+            documents=docs[i:i + CHROMA_MAX_BATCH],
+            metadatas=metas[i:i + CHROMA_MAX_BATCH],
+            ids=ids[i:i + CHROMA_MAX_BATCH],
+        )
+
+
+def _batch_delete(collection, ids):
+    for i in range(0, len(ids), CHROMA_MAX_BATCH):
+        collection.delete(ids=ids[i:i + CHROMA_MAX_BATCH])
 
 
 def git_indexable_files():
@@ -120,16 +135,8 @@ def index_files():
             })
             ids_to_upsert.append(chunk_id)
 
-    CHROMA_MAX_BATCH = 5000
-    for i in range(0, len(ids_to_upsert), CHROMA_MAX_BATCH):
-        collection.upsert(
-            documents=docs_to_upsert[i:i + CHROMA_MAX_BATCH],
-            metadatas=metas_to_upsert[i:i + CHROMA_MAX_BATCH],
-            ids=ids_to_upsert[i:i + CHROMA_MAX_BATCH],
-        )
-
-    for i in range(0, len(to_delete), CHROMA_MAX_BATCH):
-        collection.delete(ids=to_delete[i:i + CHROMA_MAX_BATCH])
+    _batch_upsert(collection, docs_to_upsert, metas_to_upsert, ids_to_upsert)
+    _batch_delete(collection, to_delete)
 
     print(
         f"Files scanned: {files_scanned} | "

--- a/tests/test_index_project.py
+++ b/tests/test_index_project.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from index_project import git_indexable_files
+from index_project import git_indexable_files, CHROMA_MAX_BATCH
 
 
 def _fake_run(tracked, untracked):
@@ -96,6 +96,46 @@ def test_chroma_db_exclusion_uses_forward_slashes():
         assert "main.py" in files
     finally:
         _ip.CHROMA_PATH = original
+
+
+def test_upsert_is_batched_when_exceeding_max_batch_size():
+    """collection.upsert must be called in multiple batches when chunks exceed CHROMA_MAX_BATCH."""
+    import index_project as _ip
+
+    num_items = CHROMA_MAX_BATCH + 1
+    ids = [f"file.py::{i}" for i in range(num_items)]
+    docs = [f"chunk {i}" for i in range(num_items)]
+    metas = [{"path": "file.py", "start_line": i, "end_line": i + 1, "hash": f"h{i}"} for i in range(num_items)]
+
+    mock_collection = MagicMock()
+    mock_collection.upsert = MagicMock()
+
+    _ip._batch_upsert(mock_collection, docs, metas, ids)
+
+    expected_calls = (num_items + CHROMA_MAX_BATCH - 1) // CHROMA_MAX_BATCH
+    assert mock_collection.upsert.call_count == expected_calls
+
+    first_call_ids = mock_collection.upsert.call_args_list[0][1]["ids"]
+    assert len(first_call_ids) == CHROMA_MAX_BATCH
+
+    last_call_ids = mock_collection.upsert.call_args_list[-1][1]["ids"]
+    assert len(last_call_ids) == num_items % CHROMA_MAX_BATCH
+
+
+def test_delete_is_batched_when_exceeding_max_batch_size():
+    """collection.delete must be called in multiple batches when ids exceed CHROMA_MAX_BATCH."""
+    import index_project as _ip
+
+    num_items = CHROMA_MAX_BATCH + 1
+    ids = [f"file.py::{i}" for i in range(num_items)]
+
+    mock_collection = MagicMock()
+    mock_collection.delete = MagicMock()
+
+    _ip._batch_delete(mock_collection, ids)
+
+    expected_calls = (num_items + CHROMA_MAX_BATCH - 1) // CHROMA_MAX_BATCH
+    assert mock_collection.delete.call_count == expected_calls
 
 
 def test_untracked_query_uses_exclude_standard():


### PR DESCRIPTION
## Summary
- ChromaDB has a max batch size of 5461; large repos (e.g. cpython) exceed this in a single upsert, causing an `InternalError`
- Split `collection.upsert()` and `collection.delete()` calls into chunks of 5000 to stay safely under the limit

## Test Plan
- [ ] Run indexing against a large repo (cpython or similar) and verify no batch size errors
- [ ] All 51 existing tests pass