### PR TITLE
Wave 1: central-install docs + fd-leak follow-ups (#38 #40 #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Returns the top 5 most relevant code chunks with file paths and line numbers.
 
 A `SessionStart` hook handles the rest automatically: it registers/watches the current repo with the central daemon, triggers a catch-up incremental index if files changed since last session, and injects the Precision Protocol (the "search before grep" rule) into context. There is nothing to start or stop manually.
 
-**Git worktrees** are auto-enabled: the first search or session in a worktree of an already-enabled repo registers that worktree with its own index, seeded by cloning the main worktree's index and then catch-up indexing — so it's ready in seconds instead of a full rebuild.
+**Git worktrees** are auto-enabled: the first session in a worktree of an already-enabled repo registers that worktree with its own index, seeded by cloning the main worktree's index and then catch-up indexing — so it's ready in seconds instead of a full rebuild.
 
 **BM25 hybrid search** is opt-in per repo. Enable it at registration time:
 
@@ -105,7 +105,7 @@ Releases are tagged as `vX.Y.Z` (e.g., `v2.0.0`). As of v2.0.0 the tool is distr
 2. Each file is split into ~60-line chunks with 10-line overlap, breaking at blank lines to keep functions intact
 3. Chunks are embedded using a model chosen by language: UniXcoder for systems languages (C/C++/Rust/Go/…), GraphCodeBERT for web/scripting, CodeBERT for config-only repos — no API key required, runs fully offline. Uses Apple MPS or AMD ROCm (auto-detected via `/dev/dxg` on WSL2) when available; otherwise CPU.
 4. On re-index, only chunks whose content has changed (SHA-256 hash comparison) are re-embedded
-5. `search_code.py` queries the vector DB (and BM25 corpus if present) and merges overlapping result chunks before printing
+5. `code-search search` queries the vector DB (and BM25 corpus if present) and merges overlapping result chunks before printing
 
 ## Eval
 

--- a/engine/client.py
+++ b/engine/client.py
@@ -48,6 +48,7 @@ def ensure_daemon() -> bool:
     subprocess.Popen([str(py), "-m", "engine.daemon"], env=env,
                      stdout=log, stderr=subprocess.STDOUT,
                      start_new_session=True)
+    log.close()   # child keeps its own inherited fd; don't leak ours in the parent
     deadline = time.time() + 15
     while time.time() < deadline:
         try:

--- a/tests/engine/test_hooks.sh
+++ b/tests/engine/test_hooks.sh
@@ -63,8 +63,9 @@ grep -qE "session_pid=$$\$" "$TMP/err5.log" \
 # Test 6: same pid-handshake regression, but for session_end.sh — it has its
 # own $PPID-vs-os.getppid() footgun (see the comment in session_end.sh) and
 # had no test covering it; a revert to os.getppid() there would go
-# undetected. REPO is already registered (Test 2) with venv.ok faked
-# (Test 3), so session_end.sh won't early-exit before reaching the pid line.
+# undetected. REPO is already registered (Test 2), so session_end.sh's
+# `if not r.registered` guard won't early-exit before reaching the pid line
+# (unlike session_start, session_end does not gate on venv.ok).
 CODE_SEARCH_SKIP_DAEMON=1 "$ROOT/hooks/session_end.sh" \
     <<< "{\"session_id\":\"s1\",\"cwd\":\"$REPO\"}" \
     2>"$TMP/err6.log" >/dev/null


### PR DESCRIPTION
Wave 1 of the central-install follow-ups (see `docs/central-install-followups-plan.md`). Stacked on #27 — base is `feature/central-install` because these fixes depend on central-install code not yet on `main`.

## Changes
- **#38 README** — replace deleted `search_code.py` ref in "How It Works" step 5 with `code-search search`; soften the worktree auto-enable claim from "first search or session" to "first session" (`cmd_search` errors on unregistered worktrees; only `session_start.sh` calls `register_worktree`).
- **#40 test_hooks.sh** — correct Test 6 comment: `session_end.sh` early-exits on `r.registered`, not `venv.ok` (unlike `session_start`).
- **#33 client.ensure_daemon** — close the inherited `daemon.log` fd in the parent after `Popen` (child keeps its own copy). Benign leak, now closed.

## Verification
- `bash tests/engine/test_hooks.sh` → **ALL HOOK TESTS PASSED** (covers the #40 comment path + #33 spawn path).
- Docs/comment changes are not otherwise unit-testable; no test residue from #32's named list falls in Wave 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)