### PR TITLE
fix: Wave 2 central-install follow-ups (WSL2/UX correctness)

### DIFF
--- a/engine/cli.py
+++ b/engine/cli.py
@@ -54,7 +54,16 @@ def cmd_search(args) -> int:
               f"Run: code-search setup   (then retry)", file=sys.stderr)
         return 1
     if not resp.get("ok"):
-        print(resp.get("error", "search failed"), file=sys.stderr)
+        status = resp.get("status")
+        if status == "warming":
+            print("index still warming up — try again shortly", file=sys.stderr)
+        elif status == "empty":
+            print("index is empty — no indexable files in this repo", file=sys.stderr)
+        elif status == "timeout":
+            print("timed out waiting for the index to warm up — try again shortly",
+                  file=sys.stderr)
+        else:
+            print(resp.get("error", "search failed"), file=sys.stderr)
         return 1
     if not resp["results"]:
         print("No results found.")

--- a/engine/client.py
+++ b/engine/client.py
@@ -74,9 +74,11 @@ def search(repo, query, n_results=5, all_files=False, use_bm25=False,
             if spawns > 3 or not ensure_daemon():
                 raise
             continue
-        if resp.get("status") == "warming" and time.time() < deadline:
-            time.sleep(2.0)
-            continue
+        if resp.get("status") == "warming":
+            if time.time() < deadline:
+                time.sleep(2.0)
+                continue
+            return {"ok": False, "status": "timeout"}
         return resp
 
 

--- a/engine/daemon.py
+++ b/engine/daemon.py
@@ -170,17 +170,20 @@ class Daemon:
         root = Path(req["repo"])
         rid = repoident.repo_id(repoident.repo_root(root) or root)
         pid = int(req["session_pid"])
+        to_stop = []
         with self.lock:
             w = self.watches.get(rid)
             if w:
                 w["sessions"].discard(pid)
                 if not w["sessions"]:
-                    w["watch"].stop()
+                    to_stop.append(w["watch"])
                     del self.watches[rid]
                     ri = self.indexes.pop(rid, None)
                     if ri:
                         ri.close()
                 self._persist_watches()
+        for w in to_stop:
+            w.stop()
         return {"ok": True}
 
     def cmd_unwatch_all(self, req):
@@ -193,10 +196,9 @@ class Daemon:
         rid = repoident.repo_id(repoident.repo_root(root) or root)
         with self.lock:
             w = self.watches.pop(rid, None)
-            if w:
-                w["watch"].stop()
             self._persist_watches()
         if w:
+            w["watch"].stop()
             # A job that already passed the start-of-job registry re-check
             # (see _queue_index) and is mid-ri.index() when disable lands is
             # not stopped by RepoWatch.stop() above — that only blocks NEW
@@ -239,7 +241,9 @@ class Daemon:
             return {"ok": False, "status": "warming"}
         ri = self._repo_index(r.repo_id, repoident.repo_root(root))
         if ri.count() == 0:
-            return {"ok": False, "status": "warming"}
+            if r.repo_id in self.queue.pending() or self.queue.active():
+                return {"ok": False, "status": "warming"}
+            return {"ok": False, "status": "empty"}
         t0 = time.time()
         try:
             results = ri.search(
@@ -292,18 +296,21 @@ class Daemon:
     def prune_loop(self):
         idle_since = time.time()
         while not self.shutting_down.wait(PRUNE_INTERVAL):
+            to_stop = []
             with self.lock:
                 for rid in list(self.watches):
                     w = self.watches[rid]
                     w["sessions"] = {p for p in w["sessions"] if _pid_alive(p)}
                     if not w["sessions"]:
-                        w["watch"].stop()
+                        to_stop.append(w["watch"])
                         del self.watches[rid]
                         ri = self.indexes.pop(rid, None)
                         if ri:
                             ri.close()
                 self._persist_watches()
                 empty = not self.watches
+            for w in to_stop:
+                w.stop()
             # A pending/active index job must block idle-exit even with no
             # watches left: RepoIndex.index() computes all embeddings before
             # the first upsert, so killing it mid-job discards everything
@@ -394,9 +401,10 @@ def main():
     except FileNotFoundError:
         pass
     with daemon.lock:
-        for w in daemon.watches.values():
-            w["watch"].stop()
+        to_stop = [w["watch"] for w in daemon.watches.values()]
         daemon._persist_watches()
+    for w in to_stop:
+        w.stop()
     daemon.queue.stop()
     lock_fh.close()
 

--- a/engine/daemon.py
+++ b/engine/daemon.py
@@ -241,7 +241,12 @@ class Daemon:
             return {"ok": False, "status": "warming"}
         ri = self._repo_index(r.repo_id, repoident.repo_root(root))
         if ri.count() == 0:
-            if r.repo_id in self.queue.pending() or self.queue.active():
+            # "empty" only if THIS repo's first index has finished (or was
+            # never queued) — a global active() check would mis-report a
+            # genuinely-empty repo as "warming" whenever any OTHER repo is
+            # indexing, which is the daemon's normal multi-repo state.
+            if r.repo_id in self.queue.pending() \
+                    or self.queue.active_repo() == r.repo_id:
                 return {"ok": False, "status": "warming"}
             return {"ok": False, "status": "empty"}
         t0 = time.time()

--- a/engine/watcher.py
+++ b/engine/watcher.py
@@ -54,7 +54,7 @@ class IndexQueue:
     def __init__(self):
         self._q = queue.Queue()
         self._pending = set()
-        self._active = False
+        self._active_repo = None   # repo_id the worker is currently indexing
         self._lock = threading.Lock()
         self._stop = object()
         self._worker = threading.Thread(target=self._run, daemon=True)
@@ -75,7 +75,7 @@ class IndexQueue:
             repo_id, fn = item
             with self._lock:
                 self._pending.discard(repo_id)
-                self._active = True
+                self._active_repo = repo_id
             try:
                 fn()
             except Exception as e:
@@ -83,7 +83,7 @@ class IndexQueue:
                       flush=True)
             finally:
                 with self._lock:
-                    self._active = False
+                    self._active_repo = None
 
     def stop(self):
         self._q.put(self._stop)
@@ -95,7 +95,13 @@ class IndexQueue:
 
     def active(self):
         with self._lock:
-            return self._active
+            return self._active_repo is not None
+
+    def active_repo(self):
+        """repo_id the worker is currently indexing, or None. Unlike active(),
+        this lets a caller ask about a SPECIFIC repo rather than "any job"."""
+        with self._lock:
+            return self._active_repo
 
 
 class _Handler(FileSystemEventHandler):

--- a/tests/engine/test_client.py
+++ b/tests/engine/test_client.py
@@ -69,6 +69,15 @@ def test_search_retries_through_warming(monkeypatch):
         stop()
 
 
+def test_search_returns_timeout_after_deadline(monkeypatch):
+    monkeypatch.setattr(client, "ensure_daemon", lambda: True)
+    monkeypatch.setattr(client, "request",
+                        lambda payload, timeout=60.0: {"ok": False,
+                                                        "status": "warming"})
+    r = client.search("/repo", "query", warm_deadline=0.0)
+    assert r == {"ok": False, "status": "timeout"}
+
+
 def test_ensure_daemon_false_without_venv():
     # venv_python() does not exist in the tmp CODE_SEARCH_HOME
     assert client.ensure_daemon() is False

--- a/tests/engine/test_daemon.py
+++ b/tests/engine/test_daemon.py
@@ -168,6 +168,67 @@ def test_unwatch_all_removes_watch_and_stops_it(monkeypatch, tmp_path):
     assert st["watched"] == {}
 
 
+def test_unwatch_stops_watch_outside_lock(monkeypatch, tmp_path):
+    """RepoWatch.stop() joins the observer thread (up to 5s) — it must never
+    be called while daemon.lock is held, or all daemon commands stall on
+    WSL2 (issue #35)."""
+    from engine import daemon as daemon_mod, registry
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    repo = make_repo(tmp_path)
+    reg = registry.enable(repo)
+
+    d = daemon_mod.Daemon()
+    r = d.cmd_watch({"repo": str(repo), "session_pid": os.getpid()})
+    assert r["ok"]
+
+    watch = d.watches[reg.repo_id]["watch"]
+    real_stop = watch.stop
+    stop_calls = []
+
+    def fake_stop():
+        acquired = d.lock.acquire(blocking=False)
+        assert acquired, "watch.stop() was called while daemon.lock was held"
+        d.lock.release()
+        stop_calls.append(True)
+        real_stop()
+
+    monkeypatch.setattr(watch, "stop", fake_stop)
+
+    resp = d.cmd_unwatch({"repo": str(repo), "session_pid": os.getpid()})
+    assert resp["ok"]
+    assert stop_calls == [True]
+
+
+def test_search_returns_empty_for_genuinely_empty_repo(monkeypatch, tmp_path):
+    """A repo whose index has been built with zero chunks must report a
+    distinct 'empty' status; a repo whose first index is still
+    queued/running must keep reporting 'warming' (issue #29)."""
+    from engine import daemon as daemon_mod, registry
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    repo = make_repo(tmp_path)
+    reg = registry.enable(repo)
+
+    d = daemon_mod.Daemon()
+    d.model_ready.set()
+
+    class FakeRI:
+        def count(self):
+            return 0
+
+    d.indexes[reg.repo_id] = FakeRI()
+
+    resp = d.cmd_search({"repo": str(repo), "query": "x"})
+    assert resp == {"ok": False, "status": "empty"}
+
+    d.queue._pending.add(reg.repo_id)
+    try:
+        resp = d.cmd_search({"repo": str(repo), "query": "x"})
+        assert resp == {"ok": False, "status": "warming"}
+    finally:
+        d.queue._pending.discard(reg.repo_id)
+    d.queue.stop()
+
+
 def test_unwatch_all_drains_active_index_job_before_closing(monkeypatch, tmp_path):
     """A job that already passed the start-of-job disabled-check and is
     mid-write when disable lands must finish before cmd_unwatch_all closes

--- a/tests/engine/test_daemon.py
+++ b/tests/engine/test_daemon.py
@@ -226,6 +226,23 @@ def test_search_returns_empty_for_genuinely_empty_repo(monkeypatch, tmp_path):
         assert resp == {"ok": False, "status": "warming"}
     finally:
         d.queue._pending.discard(reg.repo_id)
+
+    # A DIFFERENT repo actively indexing must NOT flip this empty repo to
+    # 'warming' — the active-repo check is per-repo, not global.
+    d.queue._active_repo = "some-other-repo"
+    try:
+        resp = d.cmd_search({"repo": str(repo), "query": "x"})
+        assert resp == {"ok": False, "status": "empty"}
+    finally:
+        d.queue._active_repo = None
+
+    # This repo's own first index actively running -> 'warming'.
+    d.queue._active_repo = reg.repo_id
+    try:
+        resp = d.cmd_search({"repo": str(repo), "query": "x"})
+        assert resp == {"ok": False, "status": "warming"}
+    finally:
+        d.queue._active_repo = None
     d.queue.stop()
 
 


### PR DESCRIPTION
Wave 2 of the central-install follow-ups. One PR, stacked on `feature/central-install` (base = that branch, not `main`, until #27 merges).

## #35 — RepoWatch.stop() joins observer under daemon.lock (WSL2 stall)
`RepoWatch.stop()` calls `observer.join(timeout=5)`. On WSL2 the PollingObserver interval makes this take the full 5s, and it ran while holding `daemon.lock`, stalling every other daemon command (search/status/watch) for that window.

Fix: collect the `RepoWatch` objects under the lock, then `stop()`/join **after** releasing it, at all 4 sites — `cmd_unwatch`, `cmd_unwatch_all`, `prune_loop`, and the `main()` shutdown block. Dict removal + `ri.close()` stay atomic under the lock.

## #29 — empty-repo permanent "warming" + client stale-warming
Two paired signals had no distinct "not ready" status:
- **daemon `cmd_search`**: `ri.count()==0` returned `warming` forever for a genuinely-empty repo. Now returns a distinct `empty` status when the index queue is idle for the repo; keeps `warming` while its first index is pending/running.
- **client `search`**: on `warm_deadline` expiry it returned the stale `warming` payload. Now returns `{"status": "timeout"}` so callers can tell "timed out" from "fresh warming".
- **cli**: distinct stderr messages for `warming` / `empty` / `timeout`.

## Tests
- `test_unwatch_stops_watch_outside_lock` — proves `stop()` runs with `daemon.lock` free (non-reentrant `acquire(blocking=False)`).
- `test_search_returns_empty_for_genuinely_empty_repo` — empty vs warming.
- `test_search_returns_timeout_after_deadline` — deadline → timeout.

`pytest tests/engine` → **61 passed**. Adversarial review (independent Sonnet agent): clean.

Lock-order note for Wave 3 (#30): this fix never holds `daemon.lock` across `stop()`/join; #30 (route clone through IndexQueue) can proceed without re-touching these sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
