### PR TITLE
Wave 3: central-install concurrency hardening (#30 #36 #37)

### DIFF
--- a/docs/central-install-followups-plan.md
+++ b/docs/central-install-followups-plan.md
@@ -42,9 +42,9 @@ One PR. Real pain on this machine (WSL2).
 
 ## Wave 3 — concurrency hardening  ·  model: Opus 4.8  ·  reviewer escalate to Opus if subtle
 Highest judgment. Each fix needs a real-daemon test. Aware of lock-order with #35.
-- [ ] #30 cmd_watch clone outside lock → torn sqlite. Route clone through IndexQueue.
-- [ ] #36 _load_bm25 flag-before-corpus, no lock (self-heals; set flag after corpus, under lock).
-- [ ] #37 daemon shutdown kills handler threads mid-response (graceful drain; note spec deviation).
+- [x] #30 cmd_watch clone outside lock → torn sqlite. Route clone through IndexQueue (seed_from in _queue_index; runs on single worker → serialized behind active index, no double-clone).
+- [x] #36 _load_bm25 flag-before-corpus, no lock. Double-checked lock; build into local, set flag LAST.
+- [x] #37 daemon shutdown kills handler threads mid-response. Track handler threads; drain_handlers() bounded-join at shutdown before teardown.
 
 ## Wave 4 — latent / degenerate today  ·  model: Haiku/Sonnet, opportunistic
 Fold into related feature work, not standalone.

--- a/engine/daemon.py
+++ b/engine/daemon.py
@@ -18,6 +18,7 @@ from engine.watcher import IndexQueue, RepoWatch
 IDLE_EXIT_SECONDS = 600
 PRUNE_INTERVAL = 60
 LOG_ROTATE_BYTES = 10 * 1024 * 1024
+HANDLER_DRAIN_TIMEOUT = 5.0   # bounded wait for in-flight handlers at shutdown
 
 
 def _pid_alive(pid: int) -> bool:
@@ -55,6 +56,8 @@ class Daemon:
         self.model_ready = threading.Event()
         self.model_loading = False
         self.shutting_down = threading.Event()
+        self._handlers = set()                 # live request-handler threads
+        self._handlers_lock = threading.Lock()
 
     # ---- model warmup ------------------------------------------------
     def _ensure_model_async(self):
@@ -100,6 +103,16 @@ class Daemon:
                         print(f"[restore_watches] {w['path']}: "
                               f"{type(e).__name__}: {e}", flush=True)
 
+    def drain_handlers(self, deadline: float):
+        """Wait (bounded by deadline) for in-flight request handlers to finish,
+        so shutdown doesn't cut a response mid-send."""
+        with self._handlers_lock:
+            threads = list(self._handlers)
+        for t in threads:
+            remaining = deadline - time.time()
+            if remaining > 0:
+                t.join(timeout=remaining)
+
     # ---- repo helpers --------------------------------------------------
     def _repo_index(self, rid: str, root: Path) -> RepoIndex:
         with self.lock:
@@ -107,7 +120,7 @@ class Daemon:
                 self.indexes[rid] = RepoIndex(root, paths.index_dir(rid))
             return self.indexes[rid]
 
-    def _queue_index(self, rid: str, root: Path, bm25: bool):
+    def _queue_index(self, rid: str, root: Path, bm25: bool, seed_from: Path = None):
         ri = self._repo_index(rid, root)
         def job():
             # Re-check at job start (not just at submit time): the repo may
@@ -118,6 +131,12 @@ class Daemon:
             r = registry.resolve(root)
             if not (r.family_enabled and r.registered):
                 return
+            # Seed a fresh worktree from the main index here, on the single
+            # queue worker, so the copy serializes behind any active reindex
+            # (no torn sqlite) and two racing watches can't double-clone.
+            my_idx = paths.index_dir(rid)
+            if seed_from is not None and seed_from.exists() and not my_idx.exists():
+                clone_index(seed_from, my_idx)
             self.model_ready.wait()
             ri.index(use_bm25=bm25)
             ri.invalidate_caches()
@@ -141,14 +160,17 @@ class Daemon:
         r = registry.resolve(root)
         if not r.family_enabled:
             return {"ok": False, "error": "not enabled"}
+        seed_from = None
         if not r.registered:
             r = registry.register_worktree(root)
-            # seed from main worktree's index if it exists
+            # seed from main worktree's index if it exists — but do the copy
+            # on the queue worker (see _queue_index), not inline here, so it
+            # can't clone a torn sqlite mid-reindex.
             main_idx = paths.index_dir(r.main_repo_id)
             my_idx = paths.index_dir(r.repo_id)
             if r.main_repo_id != r.repo_id and main_idx.exists() \
                     and not my_idx.exists():
-                clone_index(main_idx, my_idx)
+                seed_from = main_idx
         self._ensure_model_async()
         pid = int(req["session_pid"])
         resolved_root = repoident.repo_root(root)
@@ -163,7 +185,8 @@ class Daemon:
                 self.watches[r.repo_id] = w
             w["sessions"].add(pid)
             self._persist_watches()
-        self._queue_index(r.repo_id, resolved_root, r.bm25)  # catch-up
+        self._queue_index(r.repo_id, resolved_root, r.bm25,
+                          seed_from=seed_from)  # seed (if new) + catch-up
         return {"ok": True, "repo_id": r.repo_id}
 
     def cmd_unwatch(self, req):
@@ -349,25 +372,32 @@ def _serve(daemon: Daemon, srv: socket.socket):
             conn, _ = srv.accept()
         except socket.timeout:
             continue
-        threading.Thread(target=_handle_conn, args=(daemon, conn),
-                         daemon=True).start()
+        t = threading.Thread(target=_handle_conn, args=(daemon, conn),
+                             daemon=True)
+        with daemon._handlers_lock:
+            daemon._handlers.add(t)
+        t.start()
 
 
 def _handle_conn(daemon, conn):
-    with conn:
-        conn.settimeout(30.0)
-        buf = b""
-        try:
-            while b"\n" not in buf:
-                chunk = conn.recv(65536)
-                if not chunk:
-                    return
-                buf += chunk
-            req = json.loads(buf.split(b"\n")[0])
-            resp = daemon.handle(req)
-            conn.sendall(json.dumps(resp).encode() + b"\n")
-        except (OSError, json.JSONDecodeError):
-            pass
+    try:
+        with conn:
+            conn.settimeout(30.0)
+            buf = b""
+            try:
+                while b"\n" not in buf:
+                    chunk = conn.recv(65536)
+                    if not chunk:
+                        return
+                    buf += chunk
+                req = json.loads(buf.split(b"\n")[0])
+                resp = daemon.handle(req)
+                conn.sendall(json.dumps(resp).encode() + b"\n")
+            except (OSError, json.JSONDecodeError):
+                pass
+    finally:
+        with daemon._handlers_lock:
+            daemon._handlers.discard(threading.current_thread())
 
 
 def main():
@@ -400,11 +430,13 @@ def main():
 
     _serve(daemon, srv)
 
-    # shutdown order: unlink socket -> stop watches -> persist -> release lock
+    # shutdown order: unlink socket -> drain in-flight handlers -> stop
+    # watches -> persist -> release lock
     try:
         os.unlink(sock_final)
     except FileNotFoundError:
         pass
+    daemon.drain_handlers(time.time() + HANDLER_DRAIN_TIMEOUT)
     with daemon.lock:
         to_stop = [w["watch"] for w in daemon.watches.values()]
         daemon._persist_watches()

--- a/engine/daemon.py
+++ b/engine/daemon.py
@@ -194,6 +194,7 @@ class Daemon:
         rid = repoident.repo_id(repoident.repo_root(root) or root)
         pid = int(req["session_pid"])
         to_stop = []
+        to_close = []
         with self.lock:
             w = self.watches.get(rid)
             if w:
@@ -203,10 +204,14 @@ class Daemon:
                     del self.watches[rid]
                     ri = self.indexes.pop(rid, None)
                     if ri:
-                        ri.close()
+                        to_close.append(ri)
                 self._persist_watches()
+        # close/stop outside daemon.lock: close() -> invalidate_caches() can
+        # block on _bm25_lock behind a live search's BM25 build (see #35).
         for w in to_stop:
             w.stop()
+        for ri in to_close:
+            ri.close()
         return {"ok": True}
 
     def cmd_unwatch_all(self, req):
@@ -325,6 +330,7 @@ class Daemon:
         idle_since = time.time()
         while not self.shutting_down.wait(PRUNE_INTERVAL):
             to_stop = []
+            to_close = []
             with self.lock:
                 for rid in list(self.watches):
                     w = self.watches[rid]
@@ -334,11 +340,15 @@ class Daemon:
                         del self.watches[rid]
                         ri = self.indexes.pop(rid, None)
                         if ri:
-                            ri.close()
+                            to_close.append(ri)
                 self._persist_watches()
                 empty = not self.watches
+            # close/stop outside daemon.lock: close() -> invalidate_caches()
+            # can block on _bm25_lock behind a live search's BM25 build (#35).
             for w in to_stop:
                 w.stop()
+            for ri in to_close:
+                ri.close()
             # A pending/active index job must block idle-exit even with no
             # watches left: RepoIndex.index() computes all embeddings before
             # the first upsert, so killing it mid-job discards everything

--- a/engine/repo_index.py
+++ b/engine/repo_index.py
@@ -126,8 +126,9 @@ class RepoIndex:
         return self._client
 
     def invalidate_caches(self):
-        self._bm25 = None
-        self._bm25_loaded = False
+        with self._bm25_lock:   # same lock as _load_bm25: no torn interleave
+            self._bm25 = None
+            self._bm25_loaded = False
 
     def close(self):
         self._client = None
@@ -306,6 +307,8 @@ class RepoIndex:
         }
 
     def count(self) -> int:
+        if not self.index_dir.exists():
+            return 0   # never materialize the index dir on a read path
         try:
             return self._chroma().get_collection(COLLECTION_NAME).count()
         except Exception:

--- a/engine/repo_index.py
+++ b/engine/repo_index.py
@@ -4,6 +4,7 @@ import json
 import re
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 import chromadb
@@ -115,6 +116,7 @@ class RepoIndex:
         self._client = None
         self._bm25 = None          # (BM25Okapi, id_list) or None
         self._bm25_loaded = False
+        self._bm25_lock = threading.Lock()
 
     # -- plumbing -------------------------------------------------------
     def _chroma(self):
@@ -311,19 +313,24 @@ class RepoIndex:
 
     # -- search ---------------------------------------------------------
     def _load_bm25(self):
-        if not self._bm25_loaded:
-            self._bm25_loaded = True
+        if self._bm25_loaded:
+            return self._bm25
+        with self._bm25_lock:
+            if self._bm25_loaded:   # another thread built it while we waited
+                return self._bm25
+            result = None
             corpus_path = self.index_dir / "bm25_corpus.json"
-            self._bm25 = None
             if corpus_path.exists():
                 try:
                     from rank_bm25 import BM25Okapi
                     corpus = json.loads(corpus_path.read_text())
                     ids = list(corpus.keys())
-                    self._bm25 = (BM25Okapi(
+                    result = (BM25Okapi(
                         [_tokenize_for_bm25(corpus[c]) for c in ids]), ids)
                 except Exception:
-                    self._bm25 = None
+                    result = None
+            self._bm25 = result
+            self._bm25_loaded = True   # flag LAST: corpus is fully built now
         return self._bm25
 
     def search(self, query, n_results=5, all_files=False, use_bm25=False):

--- a/tests/engine/test_daemon.py
+++ b/tests/engine/test_daemon.py
@@ -340,6 +340,117 @@ def test_queued_index_job_skipped_for_disabled_repo(monkeypatch, tmp_path):
         "index job ran against a disabled repo and recreated its index dir"
 
 
+def test_cmd_watch_clone_serialized_through_queue(monkeypatch, tmp_path):
+    """#30: cmd_watch must not clone a worktree's seed index inline (it can copy
+    a torn sqlite while the main repo is mid-reindex). The clone must be routed
+    through IndexQueue so it serializes behind the active index job."""
+    from engine import daemon as daemon_mod, registry, repoident
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    repo = make_repo(tmp_path)
+    (repo / "auth.py").write_text("def f(): pass\n")
+    _git("add", ".", cwd=repo)
+    r_main = registry.enable(repo)
+    wt = tmp_path / "wt"
+    _git("worktree", "add", str(wt), "-b", "feat", cwd=repo)
+
+    r_wt = registry.resolve(wt)
+    assert r_wt.repo_id != r_main.repo_id, "worktree must get a distinct repo_id"
+    main_idx = paths.index_dir(r_wt.main_repo_id)
+    main_idx.mkdir(parents=True)
+    (main_idx / "sentinel").write_text("x")   # proves the clone copied main's index
+    wt_idx = paths.index_dir(r_wt.repo_id)
+
+    d = daemon_mod.Daemon()
+    d.model_ready.set()
+    monkeypatch.setattr(daemon_mod.RepoIndex, "index",
+                        lambda self, use_bm25=False: {"upserted": 0, "deleted": 0})
+
+    # Occupy the single queue worker with a blocking job.
+    gate = threading.Event()
+    started = threading.Event()
+    d.queue.submit("blocker", lambda: (started.set(), gate.wait(5)))
+    assert started.wait(5), "blocker job never started"
+
+    d.cmd_watch({"repo": str(wt), "session_pid": os.getpid()})
+    assert not wt_idx.exists(), \
+        "clone ran inline in the handler instead of behind the queue's active job"
+
+    gate.set()
+    d.queue.stop()   # drain: blocker returns, then the seed-clone + catch-up runs
+    assert (wt_idx / "sentinel").exists(), \
+        "queued job never seeded the worktree index from main"
+
+    with d.lock:
+        stops = [w["watch"] for w in d.watches.values()]
+    for w in stops:
+        w.stop()
+
+
+def test_shutdown_drains_inflight_handler(monkeypatch, tmp_path):
+    """#37: on shutdown the daemon must wait for an in-flight request handler
+    to finish instead of tearing it down mid-response."""
+    from engine import daemon as daemon_mod
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    paths.ensure_home()
+    d = daemon_mod.Daemon()
+
+    entered = threading.Event()
+    gate = threading.Event()
+
+    def slow_handle(req):
+        entered.set()
+        gate.wait(5)
+        return {"ok": True}
+
+    monkeypatch.setattr(d, "handle", slow_handle)
+
+    sock = paths.socket_path()
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(str(sock))
+    srv.listen(8)
+    serve_t = threading.Thread(target=daemon_mod._serve, args=(d, srv), daemon=True)
+    serve_t.start()
+
+    c = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    c.connect(str(sock))
+    c.sendall(b'{"cmd":"ping"}\n')
+    assert entered.wait(5), "handler never began"
+
+    d.shutting_down.set()
+    serve_t.join(5)                      # accept loop stops
+    with d._handlers_lock:
+        assert len(d._handlers) == 1, "in-flight handler not tracked"
+
+    threading.Thread(target=lambda: (time.sleep(0.2), gate.set()),
+                     daemon=True).start()
+    d.drain_handlers(time.time() + 5)
+    with d._handlers_lock:
+        assert d._handlers == set(), "handler still live after drain"
+    c.close()
+    srv.close()
+
+
+def test_drain_handlers_is_bounded(monkeypatch, tmp_path):
+    """#37: drain must not hang shutdown on a stuck handler — it honors a
+    deadline."""
+    from engine import daemon as daemon_mod
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    d = daemon_mod.Daemon()
+
+    stuck = threading.Event()   # never set within the deadline
+    t = threading.Thread(target=lambda: stuck.wait(30), daemon=True)
+    with d._handlers_lock:
+        d._handlers.add(t)
+    t.start()
+
+    t0 = time.monotonic()
+    d.drain_handlers(time.time() + 0.5)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 3, "drain ignored its deadline"
+    stuck.set()
+    t.join(1)
+
+
 def test_restore_watches_on_startup(monkeypatch, tmp_path):
     """A pre-existing watches.json with a live pid must be restored, not crash
     the daemon (regression: restore_watches used to call a nonexistent

--- a/tests/engine/test_repo_index.py
+++ b/tests/engine/test_repo_index.py
@@ -1,3 +1,6 @@
+import json
+import threading
+import time
 import pytest
 from pathlib import Path
 from tests.engine.test_repoident import make_repo, _git
@@ -67,3 +70,41 @@ def test_clone_index_then_catch_up(indexed, tmp_path_factory):
     stats = ri2.index()  # catch-up on identical tree: nothing to do
     assert stats["upserted"] == 0 and stats["deleted"] == 0
     assert ri2.search("authentication")
+
+
+def test_concurrent_load_bm25_no_torn_read(tmp_path, monkeypatch):
+    """#36: _bm25_loaded must be set AFTER the corpus is built, under a lock,
+    so a concurrent caller never observes loaded=True with _bm25 still None
+    (a transient degrade to semantic-only)."""
+    idx = tmp_path / "idx"
+    idx.mkdir()
+    (idx / "bm25_corpus.json").write_text(json.dumps({"c1": "hello world"}))
+    ri = RepoIndex(tmp_path, idx)
+
+    entered = threading.Event()
+    release = threading.Event()
+    import rank_bm25
+    real = rank_bm25.BM25Okapi
+
+    def slow(*a, **k):
+        entered.set()
+        release.wait(5)
+        return real(*a, **k)
+
+    monkeypatch.setattr(rank_bm25, "BM25Okapi", slow)
+
+    a_result = {}
+    b_result = {}
+    ta = threading.Thread(target=lambda: a_result.__setitem__("v", ri._load_bm25()))
+    ta.start()
+    assert entered.wait(5), "builder thread never entered corpus build"
+    # Concurrent caller while the builder is still constructing the corpus:
+    tb = threading.Thread(target=lambda: b_result.__setitem__("v", ri._load_bm25()))
+    tb.start()
+    time.sleep(0.1)
+    release.set()
+    ta.join(5)
+    tb.join(5)
+    assert a_result["v"] is not None
+    assert b_result["v"] is not None, \
+        "concurrent search saw a torn semantic-only state"

--- a/tests/engine/test_repo_index.py
+++ b/tests/engine/test_repo_index.py
@@ -108,3 +108,47 @@ def test_concurrent_load_bm25_no_torn_read(tmp_path, monkeypatch):
     assert a_result["v"] is not None
     assert b_result["v"] is not None, \
         "concurrent search saw a torn semantic-only state"
+
+
+def test_invalidate_caches_serializes_with_builder(tmp_path, monkeypatch):
+    """#36 follow-up: invalidate_caches must take _bm25_lock, else it can
+    interleave between the builder's two stores and leave a persistent
+    (loaded=True, _bm25=None) state that disables BM25 until the next reindex."""
+    idx = tmp_path / "idx"
+    idx.mkdir()
+    (idx / "bm25_corpus.json").write_text(json.dumps({"c1": "hello world"}))
+    ri = RepoIndex(tmp_path, idx)
+
+    entered = threading.Event()
+    release = threading.Event()
+    import rank_bm25
+    real = rank_bm25.BM25Okapi
+
+    def slow(*a, **k):
+        entered.set()
+        release.wait(5)
+        return real(*a, **k)
+
+    monkeypatch.setattr(rank_bm25, "BM25Okapi", slow)
+
+    threading.Thread(target=ri._load_bm25, daemon=True).start()
+    assert entered.wait(5), "builder never entered corpus build"
+
+    inv_done = threading.Event()
+    threading.Thread(
+        target=lambda: (ri.invalidate_caches(), inv_done.set()),
+        daemon=True).start()
+    # While the builder holds _bm25_lock, invalidate must NOT complete.
+    assert not inv_done.wait(0.3), \
+        "invalidate_caches mutated bm25 state without holding _bm25_lock"
+    release.set()
+    assert inv_done.wait(5)
+
+
+def test_count_does_not_create_index_dir(tmp_path):
+    """#30 follow-up: a read (count) must not materialize the index dir — that
+    side effect races the queued seed-clone's `not my_idx.exists()` guard."""
+    idx = tmp_path / "idx"   # intentionally absent
+    ri = RepoIndex(tmp_path, idx)
+    assert ri.count() == 0
+    assert not idx.exists(), "count() created the index dir on a read path"


### PR DESCRIPTION
Stacked on #27 (`feature/central-install`), per `docs/central-install-followups-plan.md`. Wave 3 = concurrency hardening (highest-judgment wave). All fixes TDD; two rounds of adversarial concurrency review folded in.

## Fixes
- **#30 — cmd_watch clone outside lock → torn sqlite / double-clone.** Seed-clone of a new worktree's index is now routed through `IndexQueue` (via `seed_from` in `_queue_index`), so it runs on the single worker — serialized behind any active reindex, and coalescing makes a double-clone impossible.
- **#36 — `_load_bm25` flag-before-corpus, no lock.** Double-checked `_bm25_lock`; build the corpus into a local, set `_bm25_loaded` **last**. `invalidate_caches` now takes the same lock so the two writers can't interleave into a persistent `(loaded=True, _bm25=None)` state.
- **#37 — shutdown kills handler threads mid-response.** Handler threads are tracked; shutdown calls `drain_handlers()` (bounded 5s) to join in-flight handlers before teardown.

## Review-driven follow-ups (folded in)
- `count()` no longer materializes the index dir on a read → closes a TOCTOU that the #30 deferral widened (search's dir-creating `count()` racing the seed guard).
- `ri.close()` moved out from under `daemon.lock` in `cmd_unwatch` + `prune_loop` — since `close()→invalidate_caches()` can now block on `_bm25_lock`, keeping it under the lock would reintroduce the lock-held-across-slow-work pattern #35 removed. Mirrors the existing `cmd_unwatch_all` pattern.

## Lock-order (aware of #35)
No new join/close/clone runs under `daemon.lock`. `_bm25_lock` is a strict leaf lock (never held while acquiring another).

## Test plan
- Engine suite: **67 passed / 0 failed** (61 baseline + 6 new deterministic concurrency tests).
- New tests: seed-clone serialized behind a blocked queue worker; concurrent `_load_bm25` no torn read; `invalidate_caches` serializes with builder; `count()` doesn't create the dir; shutdown drains in-flight handler; drain is bounded.
- `test_hooks.sh`: ALL PASSED. `test_e2e_central.sh`: PASSED (exercises the #30 worktree-clone path via real daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)