### PR TITLE
Wave 4 follow-ups: migrate cleanup + index-failure state (#34 #39)

### DIFF
--- a/docs/central-install-followups-plan.md
+++ b/docs/central-install-followups-plan.md
@@ -46,11 +46,12 @@ Highest judgment. Each fix needs a real-daemon test. Aware of lock-order with #3
 - [x] #36 _load_bm25 flag-before-corpus, no lock. Double-checked lock; build into local, set flag LAST.
 - [x] #37 daemon shutdown kills handler threads mid-response. Track handler threads; drain_handlers() bounded-join at shutdown before teardown.
 
-## Wave 4 — latent / degenerate today  ·  model: Haiku/Sonnet, opportunistic
+## Wave 4 — latent / degenerate today  ·  model: Haiku/Sonnet, opportunistic  ·  🔶 IN REVIEW (branch wave4-followups)
 Fold into related feature work, not standalone.
-- [ ] #31 warmup hardcodes CodeRankEmbed — fix WITH multi-model support, not before.
-- [ ] #34 migrate _clean_settings whole-block match — unreachable w/ real installer.
-- [ ] #39 migrate cross-device venv move — delete (reproducible), don't move.
+- [ ] #31 warmup hardcodes CodeRankEmbed — **DEFERRED, kept open:** blocked on multi-model support (only CodeRankEmbed exists); fix WITH it, not before.
+- [x] #34 migrate _clean_settings whole-block match — now filters per-hook-command; co-mingled user hook in same block survives. (Haiku)
+- [x] #39 migrate cross-device venv move — `.venv-code-search` now `rmtree`'d (reproducible) not trashed; new `report["deleted"]`. (Haiku)
+- [x] Wave 2 index-failure follow-up (plan line 41): first index raising reported false `empty`. IndexQueue now tracks `_failed`; cmd_search returns new `index_error` status; cli points at reindex. Race: failure recorded + active_repo cleared in one lock section. (Sonnet)
 
 ## Cross-cutting
 - #32 test debt: **no standalone pass** — write the missing test as part of each wave (setup_venv, CLI paths, prune/idle-exit). Close #32 when the residue is empty or keep as tracking.

--- a/engine/cli.py
+++ b/engine/cli.py
@@ -62,6 +62,9 @@ def cmd_search(args) -> int:
         elif status == "timeout":
             print("timed out waiting for the index to warm up — try again shortly",
                   file=sys.stderr)
+        elif status == "index_error":
+            print(f"index build failed: {resp.get('error', '')} — run "
+                  f"'code-search reindex' to retry", file=sys.stderr)
         else:
             print(resp.get("error", "search failed"), file=sys.stderr)
         return 1
@@ -84,7 +87,7 @@ def cmd_enable(args) -> int:
     report = migrate.migrate(root, dry_run=args.dry_run)
     if report["evidence"]:
         print("Old per-repo install detected:")
-        for k in ("trashed", "skipped_tracked", "gitignore_cleaned", "killed"):
+        for k in ("trashed", "deleted", "skipped_tracked", "gitignore_cleaned", "killed"):
             if report[k]:
                 print(f"  {k}: {report[k]}")
         if report["skipped_tracked"]:

--- a/engine/daemon.py
+++ b/engine/daemon.py
@@ -276,6 +276,9 @@ class Daemon:
             if r.repo_id in self.queue.pending() \
                     or self.queue.active_repo() == r.repo_id:
                 return {"ok": False, "status": "warming"}
+            err = self.queue.failed(r.repo_id)
+            if err:
+                return {"ok": False, "status": "index_error", "error": err}
             return {"ok": False, "status": "empty"}
         t0 = time.time()
         try:

--- a/engine/migrate.py
+++ b/engine/migrate.py
@@ -1,4 +1,5 @@
-"""Old per-repo install cleanup. Stdlib only. Every removal is a move to trash."""
+"""Old per-repo install cleanup. Stdlib only. Venvs are deleted
+(reproducible); every other removal is a move to trash."""
 import json
 import os
 import re
@@ -98,7 +99,31 @@ def _clean_settings(repo: Path, dry_run: bool) -> bool:
     for container in (data, data.get("hooks", {})):
         for event in list(container):
             if event in ("UserPromptSubmit", "PreToolUse", "PostToolUse"):
-                kept = [e for e in container[event] if not is_ours(e)]
+                kept = []
+                for e in container[event]:
+                    # If entry has "hooks" key, filter at individual hook level
+                    if "hooks" in e:
+                        original_hooks = e.get("hooks", [])
+                        filtered_hooks = [
+                            hook for hook in original_hooks
+                            if not any(m in json.dumps(hook) for m in HOOK_MARKERS)
+                        ]
+                        if filtered_hooks:
+                            # Some hooks remain
+                            if len(filtered_hooks) != len(original_hooks):
+                                changed = True
+                            e["hooks"] = filtered_hooks
+                            kept.append(e)
+                        else:
+                            # All hooks removed; drop entry
+                            changed = True
+                    else:
+                        # No "hooks" key; use old check
+                        if not is_ours(e):
+                            kept.append(e)
+                        else:
+                            changed = True
+
                 if len(kept) != len(container[event]):
                     changed = True
                 if kept:
@@ -133,7 +158,7 @@ def migrate(repo: Path, dry_run: bool = False) -> dict:
     repo = Path(repo).resolve()
     report = {"evidence": False, "trashed": [], "skipped_tracked": [],
               "settings_cleaned": False, "claude_md_cleaned": False,
-              "gitignore_cleaned": [], "killed": []}
+              "gitignore_cleaned": [], "deleted": [], "killed": []}
     if not detect_old_install(repo):
         return report
     report["evidence"] = True
@@ -147,16 +172,21 @@ def migrate(repo: Path, dry_run: bool = False) -> dict:
         if _is_tracked(repo, rel):
             report["skipped_tracked"].append(rel)
             continue
-        report["trashed"].append(rel)
-        if not dry_run:
-            dest = trash / rel
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            if dest.exists():
-                n = 1
-                while (candidate := dest.with_name(f"{dest.name}.{n}")).exists():
-                    n += 1
-                dest = candidate
-            shutil.move(str(target), str(dest))
+        if rel == ".venv-code-search":
+            report["deleted"].append(rel)
+            if not dry_run:
+                shutil.rmtree(target, ignore_errors=True)
+        else:
+            report["trashed"].append(rel)
+            if not dry_run:
+                dest = trash / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                if dest.exists():
+                    n = 1
+                    while (candidate := dest.with_name(f"{dest.name}.{n}")).exists():
+                        n += 1
+                    dest = candidate
+                shutil.move(str(target), str(dest))
     hooks_dir = repo / "hooks"
     if not dry_run and hooks_dir.is_dir() and not any(hooks_dir.iterdir()):
         hooks_dir.rmdir()

--- a/engine/migrate.py
+++ b/engine/migrate.py
@@ -173,9 +173,12 @@ def migrate(repo: Path, dry_run: bool = False) -> dict:
             report["skipped_tracked"].append(rel)
             continue
         if rel == ".venv-code-search":
-            report["deleted"].append(rel)
+            # No ignore_errors: a delete that fails must surface, like the
+            # trash-move branch below — never report "deleted" for a venv
+            # still on disk.
             if not dry_run:
-                shutil.rmtree(target, ignore_errors=True)
+                shutil.rmtree(target)
+            report["deleted"].append(rel)
         else:
             report["trashed"].append(rel)
             if not dry_run:

--- a/engine/watcher.py
+++ b/engine/watcher.py
@@ -55,6 +55,7 @@ class IndexQueue:
         self._q = queue.Queue()
         self._pending = set()
         self._active_repo = None   # repo_id the worker is currently indexing
+        self._failed = {}          # repo_id -> error string, last index failed
         self._lock = threading.Lock()
         self._stop = object()
         self._worker = threading.Thread(target=self._run, daemon=True)
@@ -81,8 +82,15 @@ class IndexQueue:
             except Exception as e:
                 print(f"[index-queue] {repo_id}: {type(e).__name__}: {e}",
                       flush=True)
-            finally:
+                # Record the failure in the SAME locked section that clears
+                # active_repo, so a search racing this can never observe
+                # "not active, not pending, not failed" (false "empty").
                 with self._lock:
+                    self._failed[repo_id] = f"{type(e).__name__}: {e}"
+                    self._active_repo = None
+            else:
+                with self._lock:
+                    self._failed.pop(repo_id, None)
                     self._active_repo = None
 
     def stop(self):
@@ -102,6 +110,12 @@ class IndexQueue:
         this lets a caller ask about a SPECIFIC repo rather than "any job"."""
         with self._lock:
             return self._active_repo
+
+    def failed(self, repo_id):
+        """Error string from repo_id's last index run, or None if its last
+        run (if any) succeeded."""
+        with self._lock:
+            return self._failed.get(repo_id)
 
 
 class _Handler(FileSystemEventHandler):

--- a/tests/engine/test_daemon.py
+++ b/tests/engine/test_daemon.py
@@ -246,6 +246,31 @@ def test_search_returns_empty_for_genuinely_empty_repo(monkeypatch, tmp_path):
     d.queue.stop()
 
 
+def test_search_reports_index_error_when_first_index_raised(monkeypatch, tmp_path):
+    """A repo whose first index run RAISED must not be reported as
+    genuinely 'empty' (which claims 'no indexable files' and offers no
+    retry) — it must surface as 'index_error' instead."""
+    from engine import daemon as daemon_mod, registry
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    repo = make_repo(tmp_path)
+    reg = registry.enable(repo)
+
+    d = daemon_mod.Daemon()
+    d.model_ready.set()
+
+    class FakeRI:
+        def count(self):
+            return 0
+
+    d.indexes[reg.repo_id] = FakeRI()
+    d.queue._failed[reg.repo_id] = "ValueError: bad tree-sitter grammar"
+
+    resp = d.cmd_search({"repo": str(repo), "query": "x"})
+    assert resp == {"ok": False, "status": "index_error",
+                     "error": "ValueError: bad tree-sitter grammar"}
+    d.queue.stop()
+
+
 def test_unwatch_all_drains_active_index_job_before_closing(monkeypatch, tmp_path):
     """A job that already passed the start-of-job disabled-check and is
     mid-write when disable lands must finish before cmd_unwatch_all closes

--- a/tests/engine/test_migrate.py
+++ b/tests/engine/test_migrate.py
@@ -147,3 +147,67 @@ def test_dead_pid_does_not_crash_migrate(tmp_path, monkeypatch):
     report = migrate.migrate(repo)  # must not raise
     assert report["evidence"]
     assert pid not in report["killed"]
+
+
+def test_venv_deleted_not_trashed(tmp_path):
+    """Issue #39: .venv-code-search should be deleted, not moved to trash."""
+    repo = make_repo(tmp_path)
+    old_install(repo)
+    # Create a .venv-code-search directory (untracked)
+    venv_path = repo / ".venv-code-search"
+    venv_path.mkdir()
+    (venv_path / "pyvenv.cfg").write_text("home = /usr/bin\n")
+
+    report = migrate.migrate(repo)
+
+    # Venv should be deleted, not trashed
+    assert ".venv-code-search" in report["deleted"]
+    assert ".venv-code-search" not in report["trashed"]
+    assert not venv_path.exists()
+
+    # Verify it's not in the trash directory either
+    trash = paths.trash_dir()
+    assert not any(trash.rglob(".venv-code-search"))
+
+
+def test_mixed_hooks_in_matcher_block(tmp_path):
+    """Issue #34: filter individual hooks, not whole matcher-block."""
+    repo = make_repo(tmp_path)
+    old_install(repo)
+
+    # Override settings.local.json with a block containing both our hook and user's hook
+    (repo / ".claude" / "settings.local.json").write_text(json.dumps({
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": {"type": "tools", "tools": ["Bash"]},
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/usr/local/bin/watch_index.py pre-tool"
+                        },
+                        {
+                            "type": "command",
+                            "command": "/my/own/hook.sh"
+                        }
+                    ]
+                }
+            ]
+        }
+    }))
+
+    report = migrate.migrate(repo)
+
+    # Settings should be cleaned
+    assert report["settings_cleaned"]
+
+    # Read the cleaned settings
+    settings = json.loads((repo / ".claude" / "settings.local.json").read_text())
+
+    # The block should still exist because user's hook remains
+    assert "PreToolUse" in settings["hooks"]
+
+    # The block should have only the user's hook
+    block = settings["hooks"]["PreToolUse"][0]
+    assert len(block["hooks"]) == 1
+    assert block["hooks"][0]["command"] == "/my/own/hook.sh"

--- a/tests/engine/test_watcher.py
+++ b/tests/engine/test_watcher.py
@@ -94,6 +94,28 @@ def test_index_queue_active_while_job_runs():
     q.stop()
 
 
+def test_index_queue_records_and_clears_failure():
+    """A repo whose index run raises must be flagged via failed() rather
+    than silently dropped (which made search report a false 'empty' with
+    no retry). A subsequent successful run clears the flag."""
+    q = watcher.IndexQueue()
+    def boom():
+        raise ValueError("bad tree-sitter grammar")
+    assert q.failed("r1") is None
+    q.submit("r1", boom)
+    deadline = time.time() + 5
+    while q.failed("r1") is None and time.time() < deadline:
+        time.sleep(0.02)
+    assert q.failed("r1") == "ValueError: bad tree-sitter grammar"
+
+    q.submit("r1", lambda: None)
+    deadline = time.time() + 5
+    while q.failed("r1") is not None and time.time() < deadline:
+        time.sleep(0.02)
+    assert q.failed("r1") is None
+    q.stop()
+
+
 def test_repo_watch_stop_prevents_flush_already_in_flight(tmp_path):
     """Regression: threading.Timer.cancel() is a no-op once the timer's
     function has already started, so a debounce flush racing stop() could


### PR DESCRIPTION
Wave 4 of the central-install follow-up plan. Stacked on `feature/central-install` (not `main`) per the plan — #27 not yet merged.

## Fixes
- **#39** — migrate deletes `.venv-code-search` (`shutil.rmtree`) instead of a cross-device `shutil.move` to trash. On WSL2 `/mnt/c` that move is a slow multi-GB byte copy; venvs are reproducible. New `report["deleted"]` key, shown in `code-search enable` output.
- **#34** — `_clean_settings` now filters at the individual hook-command level, not the whole matcher-block. A user hook co-mingled in the same block as ours now survives migration. (Unreachable with the real 1-hook-per-block installer, but no longer fragile.)
- **Wave 2 index-failure follow-up** (plan line 41) — a repo whose *first* index **raised** reported a false `empty` ("no indexable files") forever, no retry. `IndexQueue` now tracks `_failed`; `cmd_search` returns a new `index_error` status; the CLI points the user at `code-search reindex`. A successful re-index clears the flag.
  - **Race:** the failure is recorded and `active_repo` cleared in the *same* lock section (with the failure set first), so a search racing the worker can never observe not-active / not-pending / not-failed → false `empty`.

## Deferred
- **#31** (warmup hardcodes CodeRankEmbed) — intentionally NOT fixed; blocked on multi-model support (only one model exists). Kept open, to fix alongside that feature.

## Tests
`44 passed` across test_migrate / test_watcher / test_daemon / test_cli / test_client:
- venv deleted-not-trashed
- mixed hooks in one matcher-block (ours removed, user's kept)
- `index_error` status at both daemon (`cmd_search`) and `IndexQueue.failed()` level (record + clear-on-success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)