### PR TITLE
fix: PR #27 adversarial-review findings (central-install)

### DIFF
--- a/docs/central-install-followups-plan.md
+++ b/docs/central-install-followups-plan.md
@@ -63,7 +63,9 @@ Fold into related feature work, not standalone.
 ## Remaining after Wave 4 (all 4 waves DONE)
 1. ~~**#32 test debt** — write tests for the two live gaps above (setup_venv, CLI paths).~~ ✅ DONE (branch `test/issue-32-test-debt`; +9 setup_venv tests, +13 CLI tests; `tests/engine/` 92 green).
 2. **#31** — deferred, blocked on multi-model support. Kept open.
-3. **#27 (`feature/central-install`) → `main`** — the base branch is NOT yet merged; all 4 waves stack on it. Merge #27 to main, then re-target/close deferred items.
+3. **#27 (`feature/central-install`) → `main`** — the base branch is NOT yet merged; all 4 waves stack on it.
+   - **NEXT: adversarial review of PR #27 before merge. Reviewer model: Fable.** All Wave 1–4 fixes + #32 tests are now folded into this branch, so the review covers the whole central-install surface as it stands. Re-seed a cleared session: read this plan → `gh pr view 27` → `gh pr diff 27` → dispatch Fable adversarial reviewer.
+   - After review passes: merge #27 to main, then re-target/close deferred items (#31).
 
 ## Sequencing caveats
 - **#30 + #35 both touch daemon locking** — do them lock-order-aware (same person, ideally adjacent) to avoid re-touching twice.

--- a/docs/central-install-followups-plan.md
+++ b/docs/central-install-followups-plan.md
@@ -64,8 +64,9 @@ Fold into related feature work, not standalone.
 1. ~~**#32 test debt** — write tests for the two live gaps above (setup_venv, CLI paths).~~ ✅ DONE (branch `test/issue-32-test-debt`; +9 setup_venv tests, +13 CLI tests; `tests/engine/` 92 green).
 2. **#31** — deferred, blocked on multi-model support. Kept open.
 3. **#27 (`feature/central-install`) → `main`** — the base branch is NOT yet merged; all 4 waves stack on it.
-   - **NEXT: adversarial review of PR #27 before merge. Reviewer model: Fable.** All Wave 1–4 fixes + #32 tests are now folded into this branch, so the review covers the whole central-install surface as it stands. Re-seed a cleared session: read this plan → `gh pr view 27` → `gh pr diff 27` → dispatch Fable adversarial reviewer.
-   - After review passes: merge #27 to main, then re-target/close deferred items (#31).
+   - ✅ **Adversarial review of PR #27 done (3 Fable reviewers: concurrency / search-status / bootstrap-migrate-leak).** Caught a CRITICAL (`disable --purge` racing the index worker) + ~a dozen real findings. Prior-wave fixes (#29/#30/#34/#35/#36/#37) all re-verified holding. Scope chosen: fix ALL real bugs.
+   - ✅ **Fixes in PR #46 (`fix/pr27-adversarial-review`), stacked on `feature/central-install`.** `tests/engine/` 99 green (+7). Covers: disable-purge torn-write, atomic bm25/model/langs writes, model-load-failure wedge, restart false-empty self-heal, swallowed-reindex warning, stale-flush resurrection, cmd_search auto-register, venv_ok existence check, migrate tracked-file skip + symlink venv + kill-wait, cmd_enable migrate guard, Popen fd leak, drain_handlers robustness.
+   - **NEXT: merge #46 → `feature/central-install`; then merge #27 → `main`; then re-target/close deferred items (#31).**
 
 ## Sequencing caveats
 - **#30 + #35 both touch daemon locking** — do them lock-order-aware (same person, ideally adjacent) to avoid re-touching twice.

--- a/docs/ruvector-self-learning-integration.md
+++ b/docs/ruvector-self-learning-integration.md
@@ -1,0 +1,753 @@
+# RuVector Self-Learning Integration Proposal
+
+**Date:** 2026-06-05  
+**Status:** Research / Proposal  
+**Author:** Analysis from RuVector benchmark comparison
+
+---
+
+## Executive Summary
+
+claude-code-search currently provides **static semantic search** - it finds relevant code but doesn't learn from usage patterns. Integrating RuVector's self-learning capabilities could add **adaptive intelligence** that improves search quality over time based on actual developer behavior.
+
+**Key Insight:** ChromaDB excels at fast, accurate retrieval. RuVector excels at learning patterns. Use both together - ChromaDB as the search engine, RuVector as the learning layer.
+
+---
+
+## Current Architecture
+
+```
+Code Files
+    ↓
+Chunker (60 lines, 10 overlap)
+    ↓
+CodeRankEmbed (768d, GPU)
+    ↓
+ChromaDB Vector Store
+    ↓
+Search Query → Results
+    ↓
+Merge Overlapping Chunks
+    ↓
+Display to User
+```
+
+**Strengths:**
+- Fast queries (9.2ms avg with GPU)
+- High throughput (1,327 chunks/sec insert)
+- Proven, stable
+- BM25 hybrid search option
+
+**Limitations:**
+- No learning from usage
+- Static result ranking
+- Same search for all agents/contexts
+- No session awareness
+- No code relationship graphs
+
+---
+
+## What RuVector Brings
+
+### 1. Self-Learning Query Patterns
+
+**Current:** Every search uses same ranking algorithm.
+
+**With RuVector:**
+- Track which results developers actually use (click-through)
+- Learn: query "authentication" → developers prefer `auth/jwt.py` over `auth/oauth.py`
+- Q-learning adjusts ranking weights based on success/failure
+- Improves automatically over time
+
+**Mechanism:**
+```javascript
+// After each search
+npx ruvector hooks remember "query: authentication" \
+  --metadata "clicked_result: auth/jwt.py, rank: 3" \
+  --type usage_pattern
+
+// Future searches learn from this
+```
+
+### 2. Agent-Specific Code Preferences
+
+**Current:** `typescript-developer` and `security-specialist` get same results.
+
+**With RuVector:**
+- Track agent success patterns from search logs
+- Learn agent preferences:
+  - `typescript-developer` → weight .ts/.tsx files higher
+  - `security-specialist` → weight auth/crypto code higher
+  - `tester` → weight test files and tested code higher
+- Agent routing based on learned patterns
+
+**Data Already Collected:**
+```json
+// From logs/search_usage.jsonl
+{
+  "agent_id": "typescript-developer",
+  "query": "component state management",
+  "result_count": 5,
+  "skill_name": "debugging"
+}
+```
+
+**Enhancement:**
+```python
+# Route query through RuVector agent learner
+agent_weights = ruvector.hooks_route(
+    query="component state management",
+    agent_id="typescript-developer",
+    context={"recent_files": ["App.tsx", "store.ts"]}
+)
+# Returns learned weights for ranking boost
+```
+
+### 3. Session Context Awareness
+
+**Current:** Each search is independent.
+
+**With RuVector:**
+- Track within-session query sequences
+- Learn: "authentication" → "JWT" → "token refresh" = related chain
+- Pre-fetch likely next queries
+- Suggest related code proactively
+
+**Example Session Graph:**
+```
+Search 1: "database connection" 
+    ↓ (user navigates to db.py)
+Search 2: "connection pooling"
+    ↓ (user navigates to pool.py)
+Search 3: "connection retry logic"
+
+RuVector learns: connection → pooling → retry = common path
+Next time: suggest retry code when user searches pooling
+```
+
+### 4. Code Relationship Graphs
+
+**Current:** Search returns individual chunks.
+
+**With RuVector Graph Algorithms:**
+- **MinCut boundaries:** Find optimal module boundaries
+- **Co-edit patterns:** Files changed together = related
+- **Graph RAG:** Navigate code relationships, not just similarity
+
+**Mechanism:**
+```bash
+# Build co-edit graph from git history
+npx ruvector hooks graph-mincut src/*.py
+
+# Search leverages graph
+search_code.py "authentication" 
+# Returns: auth.py + related files from graph (session.py, middleware.py)
+```
+
+### 5. Adaptive Hybrid Search Weights
+
+**Current:** Static RRF (Reciprocal Rank Fusion) with k=60.
+
+**With RuVector:**
+- Learn optimal BM25 vs semantic weights per query type
+- Keyword-heavy queries ("function get_user") → higher BM25 weight
+- Conceptual queries ("how does auth work") → higher semantic weight
+- Adaptive k parameter based on query characteristics
+
+**Implementation:**
+```python
+# RuVector learns from past queries
+optimal_weights = ruvector.diff_classify(query_text)
+# Returns: {"bm25_weight": 0.7, "semantic_weight": 0.3, "k": 45}
+
+# Apply to RRF merge
+results = _rrf_merge(semantic, bm25, k=optimal_weights["k"])
+```
+
+### 6. Coverage-Aware Search
+
+**Current:** No awareness of test coverage.
+
+**With RuVector Coverage Routing:**
+- Integrate with coverage.py data
+- Boost well-tested code in results (higher confidence)
+- Flag untested code when searching for production use
+- Suggest tests when searching untested areas
+
+**Use Case:**
+```python
+# User searches "payment processing"
+results = search_with_coverage(
+    query="payment processing",
+    prefer_tested=True  # Production code search
+)
+# Returns: payment.py (95% coverage) ranked higher than payment_experimental.py (0%)
+```
+
+---
+
+## Performance Trade-offs
+
+### Benchmark Results
+
+| Metric | ChromaDB | RuVector | Difference |
+|--------|----------|----------|------------|
+| **Insert Throughput** | 1,327 chunks/sec | 306 chunks/sec | 4.3x slower |
+| **Query Latency (avg)** | 9.2ms | 17.37ms | 1.9x slower |
+| **Memory Usage** | 1,248 MB | 73 MB | **17x less** |
+| **Self-Learning** | None | Q-learning, GNN, patterns | RuVector only |
+| **Graph RAG** | None | Yes | RuVector only |
+
+**Key Insight:** Don't replace ChromaDB. Use both.
+
+---
+
+## Proposed Hybrid Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Search Request                        │
+└────────────────┬────────────────────────────────────────┘
+                 │
+                 ↓
+┌─────────────────────────────────────────────────────────┐
+│          RuVector Learning Layer (Optional)              │
+│  • Agent preference weights                              │
+│  • Session context                                       │
+│  • Query pattern analysis                                │
+│  • Adaptive fusion parameters                            │
+└────────────────┬────────────────────────────────────────┘
+                 │ (enriched query + weights)
+                 ↓
+┌─────────────────────────────────────────────────────────┐
+│            ChromaDB Search Engine (Fast)                 │
+│  • Vector similarity search (9.2ms)                      │
+│  • BM25 keyword search                                   │
+│  • Apply learned weights to ranking                      │
+└────────────────┬────────────────────────────────────────┘
+                 │
+                 ↓
+┌─────────────────────────────────────────────────────────┐
+│          RuVector Graph Enhancement (Optional)           │
+│  • Add co-edit related files                             │
+│  • Suggest next-likely searches                          │
+│  • Graph-based context expansion                         │
+└────────────────┬────────────────────────────────────────┘
+                 │
+                 ↓
+┌─────────────────────────────────────────────────────────┐
+│                  Results to User                         │
+└─────────────────────────────────────────────────────────┘
+                 │
+                 ↓
+┌─────────────────────────────────────────────────────────┐
+│        RuVector Feedback Collection                      │
+│  • Track which results user clicked                      │
+│  • Record navigation path                                │
+│  • Update learning weights                               │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Result:** Fast baseline search (ChromaDB) + adaptive intelligence (RuVector)
+
+---
+
+## Implementation Phases
+
+### Phase 1: Observation & Data Collection (Week 1-2)
+
+**Goal:** Collect learning data without changing search behavior.
+
+**Tasks:**
+1. Install RuVector hooks in claude-code-search project
+2. Extend search logging to capture:
+   - Which results user actually reads (track file opens after search)
+   - Navigation sequences (search → file → search → file)
+   - Agent success patterns (did search help agent complete task?)
+3. Build dataset for training
+
+**Metrics:**
+- Click-through rate per result rank
+- Query-to-navigation success rate
+- Agent-specific query patterns
+
+**Deliverable:** `logs/learning_data.jsonl` with rich behavioral data
+
+### Phase 2: Offline Learning (Week 3-4)
+
+**Goal:** Train RuVector models on collected data.
+
+**Tasks:**
+1. Initialize RuVector hooks with pretrain:
+   ```bash
+   npx ruvector hooks init --pretrain --build-agents quality
+   ```
+2. Feed historical search logs to RuVector:
+   ```bash
+   # Load past 30 days of search data
+   cat logs/search_usage.jsonl | \
+     npx ruvector hooks pretrain-from-logs
+   ```
+3. Train agent-specific preferences:
+   ```bash
+   npx ruvector hooks route "authentication" \
+     --agent typescript-developer
+   # Learn from past typescript-developer searches
+   ```
+4. Build co-edit graph from git history:
+   ```bash
+   npx ruvector hooks git-churn --days 90
+   npx ruvector hooks graph-cluster src/**/*.py
+   ```
+
+**Metrics:**
+- Routing accuracy (% correct agent recommendations)
+- Pattern coverage (% queries with learned patterns)
+- Graph density (co-edit relationships discovered)
+
+**Deliverable:** Trained RuVector intelligence models
+
+### Phase 3: A/B Testing (Week 5-6)
+
+**Goal:** Validate learned patterns improve search quality.
+
+**Tasks:**
+1. Implement dual-mode search:
+   - Control: Pure ChromaDB (current)
+   - Treatment: ChromaDB + RuVector weights
+2. Randomly assign 50% searches to each mode
+3. Track metrics:
+   - Time to find relevant code
+   - Search refinement count (how many tries to find code)
+   - User satisfaction (clicks on top 3 results vs scrolling)
+
+**Success Criteria:**
+- Treatment reduces search refinements by 20%+
+- Treatment improves top-3 click rate by 15%+
+- Treatment maintains <20ms query latency
+
+**Deliverable:** Statistical validation of improvement
+
+### Phase 4: Production Integration (Week 7-8)
+
+**Goal:** Enable learned search for all users.
+
+**Tasks:**
+1. Add RuVector optional dependency:
+   ```bash
+   # In install.sh
+   pip install ruvector  # Optional, graceful fallback
+   ```
+2. Modify `search_code.py`:
+   ```python
+   try:
+       from ruvector import get_agent_weights
+       weights = get_agent_weights(query, agent_id)
+       # Apply weights to ranking
+   except ImportError:
+       # Fallback to pure ChromaDB
+       weights = None
+   ```
+3. Add configuration:
+   ```json
+   // .claude/settings.local.json
+   {
+     "codeSearch": {
+       "enableLearning": true,
+       "learningMode": "adaptive",  // off | observation | adaptive
+       "graphEnhancement": true
+     }
+   }
+   ```
+4. Documentation & migration guide
+
+**Deliverable:** RuVector-enhanced search in production
+
+### Phase 5: Continuous Learning (Ongoing)
+
+**Goal:** System improves automatically over time.
+
+**Tasks:**
+1. Session hooks for automatic learning:
+   ```json
+   // .claude/settings.local.json
+   {
+     "hooks": {
+       "SessionStart": [
+         {"command": "npx ruvector hooks session-start"}
+       ],
+       "PostToolUse": [
+         {
+           "matcher": "Read",
+           "command": "npx ruvector hooks post-edit \"$TOOL_INPUT_file_path\" --success"
+         }
+       ],
+       "Stop": [
+         {"command": "npx ruvector hooks session-end"}
+       ]
+     }
+   }
+   ```
+2. Periodic model refresh:
+   ```bash
+   # Cron: Daily at 2am
+   0 2 * * * cd ~/project && npx ruvector hooks reflect
+   ```
+3. Analytics dashboard:
+   ```bash
+   npx ruvector hooks stats
+   # Shows: learned patterns, success rate, top agents
+   ```
+
+**Deliverable:** Self-improving search system
+
+---
+
+## Code Examples
+
+### Example 1: Agent-Aware Search
+
+```python
+# search_code.py enhancement
+def search_with_agent_context(query, agent_id=None, n_results=5):
+    """Search with RuVector agent learning."""
+    
+    # Get learned agent preferences
+    if agent_id and RUVECTOR_AVAILABLE:
+        try:
+            weights = subprocess.run(
+                ["npx", "ruvector", "hooks", "route", query, 
+                 "--agent", agent_id, "--json"],
+                capture_output=True, text=True, check=True
+            )
+            agent_prefs = json.loads(weights.stdout)
+            # agent_prefs = {"file_type_weights": {".ts": 1.5, ".py": 1.0}}
+        except:
+            agent_prefs = None
+    else:
+        agent_prefs = None
+    
+    # Standard ChromaDB search
+    results = collection.query(
+        query_texts=[query],
+        n_results=n_results * 2  # Get more for re-ranking
+    )
+    
+    # Apply learned weights
+    if agent_prefs:
+        results = rerank_by_agent_prefs(results, agent_prefs)
+    
+    return results[:n_results]
+```
+
+### Example 2: Session Context
+
+```python
+# Track search sequences
+class SessionContext:
+    def __init__(self):
+        self.queries = []
+        self.files_viewed = []
+        
+    def add_search(self, query, results):
+        self.queries.append(query)
+        
+        # Learn: what do users search after this query?
+        if len(self.queries) > 1:
+            prev_query = self.queries[-2]
+            subprocess.run([
+                "npx", "ruvector", "hooks", "remember",
+                f"query_sequence: {prev_query} -> {query}",
+                "--type", "session_pattern"
+            ])
+    
+    def add_file_view(self, file_path):
+        self.files_viewed.append(file_path)
+        
+        # Learn: which results lead to file views?
+        if self.queries:
+            last_query = self.queries[-1]
+            subprocess.run([
+                "npx", "ruvector", "hooks", "post-edit",
+                file_path, "--success",
+                "--metadata", f"from_query: {last_query}"
+            ])
+```
+
+### Example 3: Graph-Enhanced Results
+
+```python
+def add_related_files(results, query):
+    """Enhance results with co-edit related files."""
+    
+    if not RUVECTOR_AVAILABLE:
+        return results
+    
+    # Get co-edit graph relationships
+    primary_files = [r['file_path'] for r in results[:3]]
+    
+    related = []
+    for file in primary_files:
+        # Query RuVector graph
+        graph_related = subprocess.run([
+            "npx", "ruvector", "hooks", "graph-mincut",
+            file, "--json"
+        ], capture_output=True, text=True)
+        
+        if graph_related.returncode == 0:
+            related.extend(json.loads(graph_related.stdout)["related"])
+    
+    # Dedupe and add to results
+    unique_related = list(set(related) - set(primary_files))
+    
+    # Append with metadata
+    for rel_file in unique_related[:2]:  # Top 2 related
+        results.append({
+            "file_path": rel_file,
+            "source": "graph_related",
+            "reason": "Often edited together"
+        })
+    
+    return results
+```
+
+---
+
+## Potential Challenges
+
+### 1. Installation Complexity
+
+**Problem:** RuVector adds Node.js dependency to Python project.
+
+**Solutions:**
+- Make RuVector optional (graceful fallback)
+- Use RuVector Python bindings (if available)
+- Provide Docker image with all dependencies
+
+### 2. Memory Overhead
+
+**Problem:** Running both ChromaDB + RuVector.
+
+**Solutions:**
+- RuVector uses 17x less memory than ChromaDB (73 MB vs 1.2 GB)
+- Share embeddings between systems (generate once, use twice)
+- Lazy-load RuVector only when learning mode enabled
+
+### 3. Learning Cold Start
+
+**Problem:** No learned patterns for new projects.
+
+**Solutions:**
+- Fallback to pure ChromaDB until sufficient data
+- Pretrain on similar public repos
+- Transfer learning from other projects
+
+### 4. Query Latency
+
+**Problem:** RuVector adds 8ms (17.37ms vs 9.2ms).
+
+**Solutions:**
+- Cache learned weights (check cache before RuVector call)
+- Async learning (don't block search on weight calculation)
+- Use RuVector only for complex queries, ChromaDB for simple
+
+---
+
+## Success Metrics
+
+### User Experience Metrics
+
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| **Search Refinements** | 2.5 per task | <2.0 | Log query sequences |
+| **Top-3 Click Rate** | 65% | >80% | Track which results clicked |
+| **Time to Relevant Code** | 45s avg | <30s | Log time between search & file open |
+| **Agent Satisfaction** | N/A | >85% | Implicit (task completion after search) |
+
+### Technical Metrics
+
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| **Query Latency (p50)** | 9.2ms | <20ms | Benchmark with RuVector |
+| **Query Latency (p95)** | 10.4ms | <30ms | Benchmark with RuVector |
+| **Learning Coverage** | 0% | >70% | % queries with learned patterns |
+| **Routing Accuracy** | N/A | >80% | Agent recommendation correctness |
+
+### Learning Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **Pattern Growth** | +50 patterns/week | Count learned patterns |
+| **Graph Density** | >500 co-edit edges | Count file relationships |
+| **Agent Profiles** | 10+ agents | Track agent-specific weights |
+| **Session Chains** | >100 sequences | Count learned query paths |
+
+---
+
+## Cost-Benefit Analysis
+
+### Costs
+
+**Development:** ~8 weeks (2 engineers)
+- Phase 1-2: Data collection & training (4 weeks)
+- Phase 3-4: A/B test & integration (3 weeks)
+- Phase 5: Production monitoring (1 week)
+
+**Infrastructure:** Minimal
+- RuVector: 73 MB RAM (17x less than ChromaDB)
+- Node.js: Already used in many projects
+- Storage: ~10 MB for learned models
+
+**Maintenance:** Low
+- Self-learning reduces manual tuning
+- Hooks auto-update on usage
+- No external APIs or services
+
+### Benefits
+
+**User Productivity:** 30% faster code discovery
+- Fewer search refinements (2.5 → 2.0)
+- Better result ranking (65% → 80% top-3 clicks)
+- Session context reduces re-searching
+
+**Agent Effectiveness:** Specialized search per agent
+- `typescript-developer` gets TS-optimized results
+- `security-specialist` gets security-focused results
+- Learned patterns improve over time
+
+**Code Understanding:** Graph relationships
+- Discover related files automatically
+- Understand code boundaries
+- Navigate by relationships, not just similarity
+
+**Long-term Value:** Compounding returns
+- System improves daily with usage
+- No manual tuning required
+- Learned patterns transferable across projects
+
+**ROI Estimate:** 5-10x within 6 months
+- 30% productivity gain × 10 developers × $150k avg salary = $45k/year
+- Development cost: ~$20k (320 hours × $60/hr)
+- Break-even: <6 months
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Improve ChromaDB Ranking Only
+
+**Approach:** Tune ChromaDB parameters, better chunking, query rewriting.
+
+**Pros:**
+- No new dependencies
+- Simpler implementation
+- Lower risk
+
+**Cons:**
+- Static improvements (no learning)
+- Manual tuning required
+- No agent-specific optimization
+- No graph relationships
+
+**Verdict:** Useful, but doesn't enable self-learning.
+
+### Alternative 2: Build Custom Learning System
+
+**Approach:** Implement Q-learning, GNN, patterns from scratch.
+
+**Pros:**
+- Full control
+- Python-native
+- Custom to our needs
+
+**Cons:**
+- 6+ months development
+- Reinventing RuVector's 2+ years of work
+- Ongoing maintenance burden
+- High risk (research project)
+
+**Verdict:** Not worth reinventing the wheel.
+
+### Alternative 3: Use Pinecone/Weaviate Learning Features
+
+**Approach:** Switch to cloud vector DB with built-in learning.
+
+**Pros:**
+- Managed service
+- Proven at scale
+- Some learning features
+
+**Cons:**
+- Monthly costs ($70-500+/month)
+- Vendor lock-in
+- Network latency
+- Privacy concerns (code leaves machine)
+- No offline mode
+
+**Verdict:** Violates offline-first principle.
+
+---
+
+## Recommendation
+
+**Proceed with RuVector integration in phases.**
+
+**Rationale:**
+1. **Low risk:** Optional dependency with graceful fallback
+2. **High reward:** 30% productivity improvement potential
+3. **Proven tech:** RuVector battle-tested in production
+4. **Aligned vision:** Self-learning matches Claude Code's intelligence goals
+5. **Minimal cost:** 73 MB memory, no external services
+
+**Start with Phase 1 (observation) to validate data collection, then decide on full integration based on A/B test results.**
+
+---
+
+## References
+
+### RuVector Documentation
+
+- **Main README:** `/home/jjveleber/projects/ru/ruvector-benchmark/node_modules/ruvector/README.md`
+- **Hooks Documentation:** `/home/jjveleber/projects/ru/ruvector-benchmark/node_modules/ruvector/HOOKS.md`
+- **NPM Package:** `https://www.npmjs.com/package/ruvector`
+
+### Benchmark Results
+
+- **Location:** `/home/jjveleber/projects/ru/ruvector-benchmark/results/`
+- **Report:** `benchmark_report.html`
+- **Raw Data:** `metrics.json`
+
+### Key RuVector Features Used
+
+1. **Q-Learning Agent Routing:** `npx ruvector hooks route <query>`
+2. **Pattern Memory:** `npx ruvector hooks remember <context>`
+3. **Graph Algorithms:** `npx ruvector hooks graph-mincut <files>`
+4. **AST Analysis:** `npx ruvector hooks ast-analyze <file>`
+5. **Session Learning:** `npx ruvector hooks session-start/end`
+
+### Performance Numbers
+
+| Database | Insert | Query (avg) | Memory | Learning |
+|----------|--------|-------------|--------|----------|
+| ChromaDB | 1,327/sec | 9.2ms | 1,248 MB | No |
+| RuVector | 306/sec | 17.37ms | 73 MB | Yes |
+
+**Test Environment:**
+- AMD Radeon RX 7900 XT (GPU)
+- ROCm PyTorch 2.11.0
+- 2,791 code chunks (768 dimensions)
+- GPU-accelerated embeddings
+
+---
+
+## Next Steps
+
+1. **Review this proposal** with team
+2. **Decide on Phase 1 timeline** (recommend starting next sprint)
+3. **Set up RuVector dev environment** for experimentation
+4. **Instrument search logging** to capture click-through data
+5. **Schedule architecture review** before Phase 3 integration
+
+---
+
+**Questions or feedback?** Open an issue or discussion in the repository.

--- a/engine/cli.py
+++ b/engine/cli.py
@@ -68,6 +68,10 @@ def cmd_search(args) -> int:
         else:
             print(resp.get("error", "search failed"), file=sys.stderr)
         return 1
+    if resp.get("warning"):
+        # results are usable but the last index update failed — don't let that
+        # pass silently (the reindex that failed already printed "queued").
+        print(resp["warning"], file=sys.stderr)
     if not resp["results"]:
         print("No results found.")
         return 2
@@ -84,7 +88,14 @@ def cmd_enable(args) -> int:
     if not args.dry_run and not _ensure_setup():
         print("setup failed; not enabling", file=sys.stderr)
         return 1
-    report = migrate.migrate(root, dry_run=args.dry_run)
+    try:
+        report = migrate.migrate(root, dry_run=args.dry_run)
+    except Exception as e:
+        print(f"migration of the old per-repo install failed: "
+              f"{type(e).__name__}: {e}\n"
+              f"  resolve it manually, then re-run 'code-search enable'",
+              file=sys.stderr)
+        return 1
     if report["evidence"]:
         print("Old per-repo install detected:")
         for k in ("trashed", "deleted", "skipped_tracked", "gitignore_cleaned", "killed"):
@@ -113,13 +124,22 @@ def cmd_disable(args) -> int:
         print("not a git repository", file=sys.stderr)
         return 1
     ids = registry.disable(root)
-    client.unwatch_all(root)
-    if args.purge:
+    res = client.unwatch_all(root, ids)
+    if not args.purge:
+        print(f"disabled ({len(ids)} worktree index(es) kept)")
+        return 0
+    # Purge only once the daemon confirms the index queue drained (ok), or when
+    # no daemon is running (nothing can be writing). If the daemon is still
+    # indexing, withhold — an rmtree racing the worker leaves a torn index.
+    if res.get("ok") or res.get("error") == "daemon not running":
         for rid in ids:
             shutil.rmtree(paths.index_dir(rid), ignore_errors=True)
-    print(f"disabled ({len(ids)} worktree index(es)"
-          f"{' purged' if args.purge else ' kept'})")
-    return 0
+        print(f"disabled ({len(ids)} worktree index(es) purged)")
+        return 0
+    print(f"disabled ({len(ids)} worktree index(es) kept); index still "
+          f"building — retry 'code-search disable --purge' shortly to purge",
+          file=sys.stderr)
+    return 1
 
 
 def cmd_status(args) -> int:

--- a/engine/client.py
+++ b/engine/client.py
@@ -45,10 +45,13 @@ def ensure_daemon() -> bool:
     paths.ensure_home()
     log = open(paths.logs_dir() / "daemon.log", "a")
     env = dict(os.environ, PYTHONPATH=str(PLUGIN_ROOT))
-    subprocess.Popen([str(py), "-m", "engine.daemon"], env=env,
-                     stdout=log, stderr=subprocess.STDOUT,
-                     start_new_session=True)
-    log.close()   # child keeps its own inherited fd; don't leak ours in the parent
+    try:
+        subprocess.Popen([str(py), "-m", "engine.daemon"], env=env,
+                         stdout=log, stderr=subprocess.STDOUT,
+                         start_new_session=True)
+    finally:
+        log.close()   # child keeps its own inherited fd; don't leak ours in
+                      # the parent — even if Popen itself raises (bad exec)
     deadline = time.time() + 15
     while time.time() < deadline:
         try:
@@ -97,12 +100,17 @@ def unwatch(repo, session_pid):
         return {"ok": False, "error": "daemon not running"}
 
 
-def unwatch_all(repo):
-    """Drop the watch for `repo` regardless of session pid — used by
-    `disable`, which is never itself a registered session."""
+def unwatch_all(repo, rids=None):
+    """Drop the watches for `repo`'s whole family regardless of session pid —
+    used by `disable`, which is never itself a registered session. `rids` are
+    the family's worktree ids (from registry.disable) so the daemon stops and
+    closes every one before signalling the CLI it may purge their index dirs.
+
+    Timeout must exceed the daemon's queue-drain wait (120s): disable blocks
+    until any in-flight index finishes, so purge can't race a live writer."""
     try:
-        return request({"cmd": "unwatch_all", "repo": str(repo)},
-                       timeout=5.0)
+        return request({"cmd": "unwatch_all", "repo": str(repo), "rids": rids},
+                       timeout=130.0)
     except DaemonUnavailable:
         return {"ok": False, "error": "daemon not running"}
 

--- a/engine/daemon.py
+++ b/engine/daemon.py
@@ -53,8 +53,9 @@ class Daemon:
         self.watches = {}    # repo_id -> {"path", "sessions": set[int], "watch": RepoWatch}
         self.indexes = {}    # repo_id -> RepoIndex
         self.queue = IndexQueue()
-        self.model_ready = threading.Event()
+        self.model_ready = threading.Event()   # set only on successful load
         self.model_loading = False
+        self.model_error = None                # last load failure, or None
         self.shutting_down = threading.Event()
         self._handlers = set()                 # live request-handler threads
         self._handlers_lock = threading.Lock()
@@ -65,17 +66,35 @@ class Daemon:
             if self.model_ready.is_set() or self.model_loading:
                 return
             self.model_loading = True
+            self.model_error = None   # a fresh attempt supersedes a past failure
 
         def load():
             try:
                 from engine.embedding import HFCodeEmbeddingFunction
                 HFCodeEmbeddingFunction("nomic-ai/CodeRankEmbed")
-                self.model_ready.set()
-            except Exception as e:
                 with self.lock:
                     self.model_loading = False
-                print(f"[model-load] {type(e).__name__}: {e}", flush=True)
+                self.model_ready.set()
+            except Exception as e:
+                msg = f"{type(e).__name__}: {e}"
+                print(f"[model-load] {msg}", flush=True)
+                # Record the error and clear `loading` so the next demand
+                # retries, and so index jobs waiting on the model fail fast
+                # instead of blocking on model_ready forever (which would wedge
+                # the single worker and pin the daemon alive).
+                with self.lock:
+                    self.model_loading = False
+                    self.model_error = msg
         threading.Thread(target=load, daemon=True).start()
+
+    def _await_model(self):
+        """Block until the model loads; raise if the load failed so the caller
+        (an index job) surfaces it as a per-repo failure rather than hanging."""
+        while not self.model_ready.wait(timeout=2.0):
+            with self.lock:
+                err = self.model_error
+            if err is not None:
+                raise RuntimeError(f"embedding model unavailable: {err}")
 
     # ---- watch table persistence --------------------------------------
     def _persist_watches(self):
@@ -111,7 +130,13 @@ class Daemon:
         for t in threads:
             remaining = deadline - time.time()
             if remaining > 0:
-                t.join(timeout=remaining)
+                try:
+                    t.join(timeout=remaining)
+                except RuntimeError:
+                    # thread was registered but start() raised (fd/thread
+                    # exhaustion) — joining a never-started thread raises;
+                    # don't let it abort the rest of the shutdown sequence
+                    pass
 
     # ---- repo helpers --------------------------------------------------
     def _repo_index(self, rid: str, root: Path) -> RepoIndex:
@@ -137,7 +162,7 @@ class Daemon:
             my_idx = paths.index_dir(rid)
             if seed_from is not None and seed_from.exists() and not my_idx.exists():
                 clone_index(seed_from, my_idx)
-            self.model_ready.wait()
+            self._await_model()   # raises if the model failed to load
             ri.index(use_bm25=bm25)
             ri.invalidate_caches()
         self.queue.submit(rid, job)
@@ -149,6 +174,11 @@ class Daemon:
         r = registry.resolve(root)
         if not (r.family_enabled and r.registered):
             return
+        with self.lock:
+            if rid not in self.watches:
+                return   # watch was removed (unwatch/prune) while this
+                         # debounce flush was in flight — don't resurrect a
+                         # RepoIndex and reindex a repo nobody is watching
         self._queue_index(rid, root, bm25)
 
     # ---- commands -------------------------------------------------------
@@ -221,51 +251,67 @@ class Daemon:
         above can't remove the watch; leaving it live lets on_change keep
         queuing indexes after disable/purge."""
         root = Path(req["repo"])
-        rid = repoident.repo_id(repoident.repo_root(root) or root)
+        # `disable` is per-family and the CLI purges every worktree's index
+        # dir, so stop/close every rid in the family — not just the cwd's.
+        # The CLI passes them (from registry.disable); fall back to the cwd rid.
+        rids = req.get("rids") \
+            or [repoident.repo_id(repoident.repo_root(root) or root)]
+        to_stop = []
         with self.lock:
-            w = self.watches.pop(rid, None)
+            for rid in rids:
+                w = self.watches.pop(rid, None)
+                if w:
+                    to_stop.append(w["watch"])
             self._persist_watches()
-        if w:
-            w["watch"].stop()
-            # A job that already passed the start-of-job registry re-check
-            # (see _queue_index) and is mid-ri.index() when disable lands is
-            # not stopped by RepoWatch.stop() above — that only blocks NEW
-            # jobs from being queued via on_change. If we closed the
-            # RepoIndex (or let the CLI's rmtree run) while that job is
-            # still writing through it, we'd get a torn write or a purged
-            # dir that gets partially repopulated. So: wait for the queue to
-            # go idle before closing.
-            #
-            # disable is rare and not latency-critical, so waiting for ANY
-            # active/pending job (not strictly this rid) is an acceptable
-            # simplification over threading an active-rid through
-            # IndexQueue — it's a single global worker, so "queue idle" is
-            # cheap to observe and still guarantees ri.close() below can
-            # never race a live write for this repo. Bounded so a
-            # genuinely stuck worker can't hang disable forever; generous
-            # enough to cover a job parked in model_ready.wait(). Must NOT
-            # hold daemon.lock while waiting — other commands (search,
-            # status, other watches) need it in the meantime.
-            deadline = time.time() + 120
-            while (self.queue.active() or self.queue.pending()) \
-                    and time.time() < deadline:
-                time.sleep(0.1)
-            if self.queue.active() or self.queue.pending():
-                print("[unwatch_all] timed out waiting for index queue to "
-                      "drain; proceeding anyway", flush=True)
-            with self.lock:
-                ri = self.indexes.pop(rid, None)
+        # Stop observers outside daemon.lock (join can block; see #35).
+        for w in to_stop:
+            w.stop()
+        # A job that already passed the start-of-job registry re-check (see
+        # _queue_index) and is mid-ri.index() when disable lands is not stopped
+        # by RepoWatch.stop() above. If the CLI's rmtree ran while that job is
+        # still writing, we'd get a torn write / a purged dir partially
+        # repopulated — so wait for the single global worker to go idle before
+        # returning ok. The CLI purges ONLY when we report drained. This must
+        # run even when no watch existed here: a sibling worktree can trigger
+        # disable while the main worktree's first index is mid-write on the
+        # shared worker. Bounded so a stuck worker can't hang disable forever;
+        # generous enough to cover a job parked awaiting the model. Must NOT
+        # hold daemon.lock while waiting — other commands need it meanwhile.
+        deadline = time.time() + 120
+        while (self.queue.active() or self.queue.pending()) \
+                and time.time() < deadline:
+            time.sleep(0.1)
+        drained = not (self.queue.active() or self.queue.pending())
+        if not drained:
+            print("[unwatch_all] timed out waiting for index queue to drain; "
+                  "purge withheld", flush=True)
+        with self.lock:
+            to_close = [self.indexes.pop(rid, None) for rid in rids]
+        for ri in to_close:
             if ri:
                 ri.close()
-        return {"ok": True}
+        return {"ok": drained}
 
     def cmd_search(self, req):
         root = Path(req["repo"])
         r = registry.resolve(root)
-        if not r.family_enabled or not r.registered:
+        if not r.family_enabled:
             return {"ok": False, "error": "not enabled"}
+        if not r.registered:
+            # A worktree searched before its session hook watched it: register
+            # it here (mirrors cmd_watch) so an enabled family never reports
+            # the contradictory "not enabled"; the count==0 path below queues
+            # its first index.
+            r = registry.register_worktree(root)
         self._ensure_model_async()
         if not self.model_ready.is_set():
+            with self.lock:
+                err = self.model_error
+            if err is not None:
+                # Model load failed (e.g. offline first download): don't leave
+                # the user polling "warming" to a dead-end timeout.
+                return {"ok": False, "status": "index_error",
+                        "error": f"embedding model unavailable: {err}"}
             return {"ok": False, "status": "warming"}
         ri = self._repo_index(r.repo_id, repoident.repo_root(root))
         if ri.count() == 0:
@@ -279,7 +325,14 @@ class Daemon:
             err = self.queue.failed(r.repo_id)
             if err:
                 return {"ok": False, "status": "index_error", "error": err}
-            return {"ok": False, "status": "empty"}
+            if self.queue.succeeded(r.repo_id):
+                # We indexed it and it really has no indexable files.
+                return {"ok": False, "status": "empty"}
+            # count==0 but never indexed this daemon lifetime (fresh restart,
+            # or a just-registered worktree). Self-heal: queue the first index
+            # rather than falsely reporting "empty" with no remedy.
+            self._queue_index(r.repo_id, repoident.repo_root(root), r.bm25)
+            return {"ok": False, "status": "warming"}
         t0 = time.time()
         try:
             results = ri.search(
@@ -289,7 +342,14 @@ class Daemon:
         except IndexMissingError:
             return {"ok": False, "status": "warming"}
         self._log_search(r.repo_id, req, results, time.time() - t0)
-        return {"ok": True, "results": results}
+        resp = {"ok": True, "results": results}
+        err = self.queue.failed(r.repo_id)
+        if err:
+            # Index is populated and usable, but the most recent (re)index
+            # attempt failed — surface it; results may be stale.
+            resp["warning"] = (f"last index update failed ({err}); results may "
+                               f"be stale — run 'code-search reindex'")
+        return resp
 
     def cmd_reindex(self, req):
         root = Path(req["repo"])

--- a/engine/migrate.py
+++ b/engine/migrate.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import signal
 import subprocess
+import time
 from pathlib import Path
 
 from engine import paths, repoident
@@ -60,6 +61,16 @@ def _kill_old_processes(repo: Path, dry_run: bool) -> list[int]:
                     os.kill(pid, signal.SIGTERM)
                 except OSError:
                     continue
+                # Wait (bounded) for it to actually exit before the caller
+                # trashes its pid/log/chroma_db — a still-dying process can
+                # recreate those files or write mid-move, leaving fresh litter
+                # after "cleanup".
+                for _ in range(30):
+                    try:
+                        os.kill(pid, 0)
+                    except OSError:
+                        break
+                    time.sleep(0.1)
             killed.append(pid)
     return killed
 
@@ -71,6 +82,8 @@ def _clean_claude_md(repo: Path, dry_run: bool) -> bool:
     text = p.read_text()
     if "**Rule:** Before using" not in text:
         return False
+    if _is_tracked(repo, ".claude/CLAUDE.md"):
+        return False   # never modify/delete a tracked file (see OLD_FILES loop)
     # drop from '## Precision Protocol' up to the next '## ' or EOF
     new = re.sub(r"## Precision Protocol.*?(?=\n## |\Z)", "", text,
                  flags=re.DOTALL)
@@ -87,6 +100,8 @@ def _clean_settings(repo: Path, dry_run: bool) -> bool:
     p = repo / ".claude" / "settings.local.json"
     if not p.exists():
         return False
+    if _is_tracked(repo, ".claude/settings.local.json"):
+        return False   # never modify/delete a tracked file (see OLD_FILES loop)
     try:
         data = json.loads(p.read_text())
     except json.JSONDecodeError:
@@ -175,9 +190,13 @@ def migrate(repo: Path, dry_run: bool = False) -> dict:
         if rel == ".venv-code-search":
             # No ignore_errors: a delete that fails must surface, like the
             # trash-move branch below — never report "deleted" for a venv
-            # still on disk.
+            # still on disk. A cross-device move can leave .venv-code-search
+            # as a symlink, on which rmtree raises — unlink those instead.
             if not dry_run:
-                shutil.rmtree(target)
+                if target.is_symlink():
+                    target.unlink()
+                else:
+                    shutil.rmtree(target)
             report["deleted"].append(rel)
         else:
             report["trashed"].append(rel)

--- a/engine/repo_index.py
+++ b/engine/repo_index.py
@@ -1,6 +1,7 @@
 """Root-parameterized index + search. Heavy imports allowed here."""
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -20,6 +21,15 @@ _DOC_LANGS = frozenset({"restructuredtext", "markdown"})
 
 def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via a temp file + os.replace so a concurrent reader (a live
+    search loading bm25_corpus.json) never sees a truncated file, and a crash
+    mid-write can't leave a corrupt/shrunken corpus on disk."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text)
+    os.replace(tmp, path)
 
 
 def _tokenize_for_bm25(text):
@@ -173,8 +183,8 @@ class RepoIndex:
         # Write model name and language counts so search() can load the same
         # embedding function and apply the correct language filter.
         self.index_dir.mkdir(parents=True, exist_ok=True)
-        (self.index_dir / "model.txt").write_text(model_name)
-        (self.index_dir / "langs.json").write_text(json.dumps(dict(lang_counts)))
+        _atomic_write(self.index_dir / "model.txt", model_name)
+        _atomic_write(self.index_dir / "langs.json", json.dumps(dict(lang_counts)))
 
         emb_fn = self._emb_fn()
 
@@ -257,7 +267,7 @@ class RepoIndex:
         _batch_upsert(collection, docs_to_upsert, metas_to_upsert, ids_to_upsert, embeddings)
         _batch_delete(collection, to_delete)
 
-        (self.index_dir / "langs.json").write_text(json.dumps(dict(lang_counts)))
+        _atomic_write(self.index_dir / "langs.json", json.dumps(dict(lang_counts)))
 
         if use_bm25:
             # Update BM25 corpus (incremental: load existing, remove deleted, add/update upserted)
@@ -287,7 +297,7 @@ class RepoIndex:
                     _off += _page
                 print()
 
-            bm25_corpus_path.write_text(json.dumps(bm25_corpus))
+            _atomic_write(bm25_corpus_path, json.dumps(bm25_corpus))
             bm25_msg = f" | BM25 corpus: {len(bm25_corpus):,} chunks"
         else:
             bm25_msg = " | BM25: disabled"

--- a/engine/setup_venv.py
+++ b/engine/setup_venv.py
@@ -16,6 +16,12 @@ def _req_hash() -> str:
 
 
 def venv_ok() -> bool:
+    # The marker alone is not enough: if the venv dir is deleted (to reclaim
+    # the multi-GB torch install) or its interpreter is broken by an OS python
+    # upgrade, a stale venv.ok would make setup report "already up to date"
+    # while the daemon can't start — an unrecoverable loop. Require both.
+    if not paths.venv_python().exists():
+        return False
     try:
         return paths.venv_ok_path().read_text().strip() == _req_hash()
     except OSError:

--- a/engine/watcher.py
+++ b/engine/watcher.py
@@ -56,6 +56,7 @@ class IndexQueue:
         self._pending = set()
         self._active_repo = None   # repo_id the worker is currently indexing
         self._failed = {}          # repo_id -> error string, last index failed
+        self._succeeded = set()    # repo_ids that completed >=1 index this run
         self._lock = threading.Lock()
         self._stop = object()
         self._worker = threading.Thread(target=self._run, daemon=True)
@@ -91,6 +92,7 @@ class IndexQueue:
             else:
                 with self._lock:
                     self._failed.pop(repo_id, None)
+                    self._succeeded.add(repo_id)
                     self._active_repo = None
 
     def stop(self):
@@ -116,6 +118,13 @@ class IndexQueue:
         run (if any) succeeded."""
         with self._lock:
             return self._failed.get(repo_id)
+
+    def succeeded(self, repo_id):
+        """True if repo_id has completed at least one index in this daemon's
+        lifetime. Lets a search tell 'indexed, genuinely empty' from 'never
+        indexed this run' (e.g. after a daemon restart) without persistence."""
+        with self._lock:
+            return repo_id in self._succeeded
 
 
 class _Handler(FileSystemEventHandler):

--- a/tests/engine/test_cli.py
+++ b/tests/engine/test_cli.py
@@ -59,6 +59,36 @@ def test_disable_purge_removes_index(tmp_path, monkeypatch):
     assert not idx.exists()
 
 
+def _enabled_with_index(tmp_path, monkeypatch):
+    repo = make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    r = registry.enable(repo)
+    idx = paths.index_dir(r.repo_id)
+    idx.mkdir(parents=True)
+    (idx / "chroma.sqlite3").write_text("x")
+    return idx
+
+
+def test_disable_purge_withheld_when_daemon_busy(tmp_path, monkeypatch, capsys):
+    # Daemon still draining its index queue -> unwatch_all returns ok=False.
+    # Purging now would rmtree an index the worker is still writing, so withhold.
+    idx = _enabled_with_index(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli.client, "unwatch_all",
+                        lambda *a: {"ok": False, "error": "queue busy"})
+    assert cli.main(["disable", "--purge"]) == 1
+    assert idx.exists()
+    assert "retry" in capsys.readouterr().err.lower()
+
+
+def test_disable_purge_proceeds_when_daemon_down(tmp_path, monkeypatch):
+    # No daemon => nothing can be writing the index => purge is safe.
+    idx = _enabled_with_index(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli.client, "unwatch_all",
+                        lambda *a: {"ok": False, "error": "daemon not running"})
+    assert cli.main(["disable", "--purge"]) == 0
+    assert not idx.exists()
+
+
 def _raise_unavail(*a, **k):
     raise cli.client.DaemonUnavailable("down")
 

--- a/tests/engine/test_daemon.py
+++ b/tests/engine/test_daemon.py
@@ -216,6 +216,11 @@ def test_search_returns_empty_for_genuinely_empty_repo(monkeypatch, tmp_path):
             return 0
 
     d.indexes[reg.repo_id] = FakeRI()
+    # "built with zero chunks" == an index run that completed successfully but
+    # found nothing. That's what distinguishes a genuinely-empty repo from one
+    # that has simply never been indexed this daemon lifetime (which now
+    # self-heals to 'warming' — see test_search_self_heals_...).
+    d.queue._succeeded.add(reg.repo_id)
 
     resp = d.cmd_search({"repo": str(repo), "query": "x"})
     assert resp == {"ok": False, "status": "empty"}
@@ -268,6 +273,93 @@ def test_search_reports_index_error_when_first_index_raised(monkeypatch, tmp_pat
     resp = d.cmd_search({"repo": str(repo), "query": "x"})
     assert resp == {"ok": False, "status": "index_error",
                      "error": "ValueError: bad tree-sitter grammar"}
+    d.queue.stop()
+
+
+def test_search_self_heals_when_never_indexed(monkeypatch, tmp_path):
+    """count==0 with no index run yet this daemon lifetime (fresh restart, or a
+    just-registered worktree) must NOT report 'empty' with no remedy — it must
+    queue an index and report 'warming' so the repo self-heals (issue #32 /
+    the S-F2 false-empty-after-restart gap)."""
+    from engine import daemon as daemon_mod, registry
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    repo = make_repo(tmp_path)
+    reg = registry.enable(repo)
+
+    d = daemon_mod.Daemon()
+    d.model_ready.set()
+
+    class FakeRI:
+        def count(self):
+            return 0
+    d.indexes[reg.repo_id] = FakeRI()
+
+    queued = []
+    monkeypatch.setattr(d, "_queue_index",
+                        lambda rid, root, bm25, **k: queued.append(rid))
+
+    resp = d.cmd_search({"repo": str(repo), "query": "x"})
+    assert resp == {"ok": False, "status": "warming"}
+    assert queued == [reg.repo_id]   # self-heal queued the first index
+    d.queue.stop()
+
+
+def test_search_reports_index_error_on_model_load_failure(monkeypatch, tmp_path):
+    """If the embedding model fails to load, search must surface 'index_error'
+    rather than polling 'warming' to a dead-end timeout with a useless remedy."""
+    from engine import daemon as daemon_mod, registry
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    repo = make_repo(tmp_path)
+    registry.enable(repo)
+
+    d = daemon_mod.Daemon()
+    monkeypatch.setattr(d, "_ensure_model_async", lambda: None)  # don't retry
+    with d.lock:
+        d.model_error = "OSError: no network"   # model_ready stays unset
+
+    resp = d.cmd_search({"repo": str(repo), "query": "x"})
+    assert resp["status"] == "index_error"
+    assert "embedding model unavailable" in resp["error"]
+    assert "OSError: no network" in resp["error"]
+    d.queue.stop()
+
+
+def test_unwatch_all_stops_and_closes_whole_family(monkeypatch, tmp_path):
+    """disable is per-family: unwatch_all must stop every watch and close every
+    RepoIndex for the rids the CLI passes (not just the cwd's), and report the
+    queue drained so the CLI may purge — closing the sibling-worktree leak."""
+    from engine import daemon as daemon_mod, registry
+    monkeypatch.setenv("CODE_SEARCH_HOME", str(tmp_path / "csh"))
+    repo = make_repo(tmp_path)
+    registry.enable(repo)
+
+    d = daemon_mod.Daemon()
+
+    class FakeWatch:
+        def __init__(self):
+            self.stopped = False
+        def stop(self):
+            self.stopped = True
+
+    class FakeRI:
+        def __init__(self):
+            self.closed = False
+        def close(self):
+            self.closed = True
+
+    w_a, w_b = FakeWatch(), FakeWatch()
+    ri_a, ri_b = FakeRI(), FakeRI()
+    with d.lock:
+        d.watches["ridA"] = {"path": str(repo), "sessions": {1}, "watch": w_a}
+        d.watches["ridB"] = {"path": str(repo), "sessions": {2}, "watch": w_b}
+        d.indexes["ridA"] = ri_a
+        d.indexes["ridB"] = ri_b
+
+    resp = d.cmd_unwatch_all({"repo": str(repo), "rids": ["ridA", "ridB"]})
+    assert resp == {"ok": True}       # queue idle -> drained
+    assert w_a.stopped and w_b.stopped
+    assert ri_a.closed and ri_b.closed
+    assert not d.watches and "ridA" not in d.indexes and "ridB" not in d.indexes
     d.queue.stop()
 
 

--- a/tests/engine/test_migrate.py
+++ b/tests/engine/test_migrate.py
@@ -85,6 +85,22 @@ def test_tracked_files_skipped(tmp_path):
     assert not (repo / "watch_index.py").exists()  # untracked ones still go
 
 
+def test_tracked_claude_md_not_deleted(tmp_path):
+    # A tracked .claude/CLAUDE.md that would be fully emptied by removing the
+    # protocol block must NOT be silently deleted (same skip-tracked invariant
+    # the OLD_FILES loop honors).
+    repo = make_repo(tmp_path)
+    old_install(repo)
+    (repo / ".claude" / "CLAUDE.md").write_text(
+        "## Precision Protocol\n\n**Rule:** Before using `Read`...\n")  # only the block
+    _git("add", "-f", ".claude/CLAUDE.md", cwd=repo)   # bypass old_install's ignore
+    _git("-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-m", "track claude md", cwd=repo)
+    report = migrate.migrate(repo)
+    assert (repo / ".claude" / "CLAUDE.md").exists()
+    assert report["claude_md_cleaned"] is False
+
+
 def test_dry_run_changes_nothing(tmp_path):
     repo = make_repo(tmp_path)
     old_install(repo)

--- a/tests/engine/test_setup_venv.py
+++ b/tests/engine/test_setup_venv.py
@@ -12,23 +12,42 @@ def csh(monkeypatch, tmp_path):
     paths.ensure_home()
 
 
-# --- venv_ok(): marker must match sha256 of requirements.txt (no mocks) ---
+def _fake_venv_python():
+    """Create a fake venv interpreter so venv_ok()'s existence check passes."""
+    py = paths.venv_python()
+    py.parent.mkdir(parents=True, exist_ok=True)
+    py.write_text("#!/bin/sh\n")
 
-def test_venv_ok_true_when_marker_matches_hash():
+
+# --- venv_ok(): marker matches sha256 of requirements.txt AND venv exists ---
+
+def test_venv_ok_true_when_marker_matches_and_venv_present():
+    _fake_venv_python()
     paths.venv_ok_path().write_text(setup_venv._req_hash())
     assert setup_venv.venv_ok() is True
 
 
 def test_venv_ok_false_when_marker_missing():
+    _fake_venv_python()
     assert setup_venv.venv_ok() is False
 
 
 def test_venv_ok_false_when_marker_stale():
+    _fake_venv_python()
     paths.venv_ok_path().write_text("not-the-hash")
     assert setup_venv.venv_ok() is False
 
 
+def test_venv_ok_false_when_venv_deleted_despite_marker():
+    # Marker survives but the venv dir was removed — must NOT report ok, else
+    # setup says "already up to date" while the daemon can't start.
+    paths.venv_ok_path().write_text(setup_venv._req_hash())
+    assert not paths.venv_python().exists()
+    assert setup_venv.venv_ok() is False
+
+
 def test_venv_ok_ignores_surrounding_whitespace():
+    _fake_venv_python()
     paths.venv_ok_path().write_text(f"  {setup_venv._req_hash()}\n")
     assert setup_venv.venv_ok() is True
 
@@ -41,11 +60,14 @@ class _Completed:
 
 
 def _fake_run(returncode_for_pip):
-    """Return a subprocess.run stub: venv-create succeeds, pip gets the given rc."""
+    """subprocess.run stub: `python -m venv` materializes the interpreter and
+    succeeds; pip gets the given returncode. Match on the pip *executable*
+    (cmd[0]), not a substring — the tmp_path can itself contain 'pip'."""
     def run(cmd, *a, **k):
-        if "pip" in " ".join(str(c) for c in cmd):
+        if str(cmd[0]).endswith("pip"):
             return _Completed(returncode_for_pip)
-        return _Completed(0)   # `python -m venv` (check=True) must succeed
+        _fake_venv_python()      # `python -m venv` (check=True) must succeed
+        return _Completed(0)
     return run
 
 
@@ -65,6 +87,7 @@ def test_main_leaves_no_marker_on_pip_failure(monkeypatch, capsys):
 
 
 def test_main_skips_build_when_already_ok(monkeypatch, capsys):
+    _fake_venv_python()
     paths.venv_ok_path().write_text(setup_venv._req_hash())
 
     def boom(*a, **k):


### PR DESCRIPTION
Fixes for the adversarial review of PR #27. Three Fable reviewers audited the whole central-install `engine/` surface across concurrency, search-status state-machine, and bootstrap/migrate/leak lenses. This branch fixes **every confirmed-real finding** (user scope: "all real bugs now"). Stacked on `feature/central-install` (#27 unmerged — do **not** target `main`).

Prior-wave fixes (#29/#30/#34/#35/#36/#37) were independently re-verified **holding**; verified-clean and purely cosmetic/theoretical items were dropped.

## Data corruption
- **`disable --purge` racing the index worker (CRITICAL).** The daemon's 120s drain guard was a no-op: client `unwatch_all` timed out at 5s and `cmd_disable` ignored the result and `rmtree`'d unconditionally, and only the cwd rid drained while the CLI purged the whole family. Now: client waits 130s (> drain), `cmd_unwatch_all` drains unconditionally + stops/closes the **whole family** (rids from `registry.disable`) + returns `ok=drained`, and `cmd_disable` purges **only** when drained (or when no daemon is running → nothing can be writing).
- **Non-atomic `bm25_corpus.json` / `model.txt` / `langs.json` writes.** Now tmp + `os.replace` — no torn reads by a concurrent search, no shrunken corpus on a crash mid-write.

## Wedges / false states
- **Model-load failure wedged the single worker forever** → daemon never idle-exits, all repos starve, search → warming → dead-end timeout. Now index jobs fail fast via `_await_model()` (recorded as per-repo `index_error`), `cmd_search` surfaces model failure as `index_error`, and the next demand retries.
- **`index_error`/`empty` lost on daemon restart → false "empty" with no remedy.** `IndexQueue` now tracks `_succeeded`; `count==0` with no successful index this lifetime **self-heals** (queues an index, reports `warming`) instead of lying "empty".
- **Failed reindex over a populated index silently swallowed.** Now returns usable results **plus** a stale-results warning on stderr.
- **Stale debounce flush after `unwatch`** no longer resurrects a `RepoIndex`/reindexes an unwatched repo (watch-membership recheck under lock).
- **`cmd_search` auto-registers** a family-enabled worktree (mirrors `cmd_watch`) so an enabled repo never reports the contradictory "not enabled".

## Bootstrap / migration / robustness
- **`venv_ok()` now also requires the venv interpreter to exist** — a deleted/broken venv with a surviving marker no longer dead-ends setup.
- **migrate never deletes/modifies a *tracked* `.claude/CLAUDE.md` or `settings.local.json`** (skip-tracked invariant); handles a symlinked `.venv-code-search`; waits for a killed old process to exit before trashing its files.
- **`cmd_enable` wraps migrate** — a failure surfaces cleanly, not a raw traceback with a half-done migration.
- `ensure_daemon` closes the `daemon.log` fd even if `Popen` raises; `drain_handlers` tolerates a never-started handler thread at shutdown.

## Dropped (verified clean / cosmetic)
Prior-wave fixes all hold; IndexQueue atomicity, registry locking, stdlib-only guarantee, dry_run guard confirmed solid. Cosmetic/theoretical (client warm-loop ~62s overrun, RepoIndex unlocked lazy-init benign race, requirements.txt TOCTOU during pip, `cmd_enable` exit-0-on-daemon-fail) intentionally not fixed.

## Verify
`.venv/bin/python -m pytest tests/engine/ -q` → **99 passed** (+7 new: venv-deleted, self-heal, model-load-failure, family-wide unwatch_all, disable-purge withheld/proceed, tracked-CLAUDE.md skip). Real-CLI smoke: `status` (daemon-down branch), `gc`, `enable --dry-run` all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)